### PR TITLE
feat(dev-preset): プリセット適用でゲーム開始直前まで自動遷移

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,340 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>保育園タイピングゲーム</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 12px;
+            padding: 30px;
+            box-shadow: 0 8px 32px rgba(0,0,0,0.1);
+        }
+
+        h1 {
+            color: #4a5568;
+            text-align: center;
+            margin-bottom: 10px;
+            font-size: 2.5em;
+        }
+
+        .subtitle {
+            text-align: center;
+            color: #718096;
+            margin-bottom: 40px;
+            font-size: 1.1em;
+        }
+
+        .game-phases {
+            display: flex;
+            justify-content: center;
+            margin-bottom: 30px;
+            background: #f7fafc;
+            padding: 20px;
+            border-radius: 8px;
+        }
+
+        .phase {
+            padding: 10px 20px;
+            margin: 0 5px;
+            border-radius: 20px;
+            font-weight: bold;
+            transition: all 0.3s;
+        }
+
+        .phase.active {
+            background: #4299e1;
+            color: white;
+        }
+
+        .phase.inactive {
+            background: #e2e8f0;
+            color: #a0aec0;
+        }
+
+        .section {
+            margin-bottom: 30px;
+            padding: 25px;
+            background: #f8fafc;
+            border-radius: 8px;
+            border-left: 4px solid #4299e1;
+        }
+
+        .section h3 {
+            margin-top: 0;
+            color: #2d3748;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .keyboards-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            margin-top: 20px;
+        }
+
+        .keyboard-card {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            border: 2px solid #e2e8f0;
+            position: relative;
+            transition: all 0.3s;
+        }
+
+        .keyboard-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+
+        .keyboard-card.connected {
+            border-color: #48bb78;
+            background: #f0fff4;
+        }
+
+        .keyboard-card.disconnected {
+            border-color: #f56565;
+            background: #fffafa;
+            opacity: 0.7;
+        }
+
+        .keyboard-status {
+            position: absolute;
+            top: 15px;
+            right: 15px;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: bold;
+        }
+
+        .keyboard-status.connected {
+            background: #48bb78;
+            color: white;
+        }
+
+        .keyboard-status.disconnected {
+            background: #f56565;
+            color: white;
+        }
+
+        .keyboard-name {
+            font-weight: bold;
+            color: #2d3748;
+            margin-bottom: 8px;
+            font-size: 1.1em;
+        }
+
+        .keyboard-info {
+            font-size: 13px;
+            color: #718096;
+            margin-bottom: 15px;
+        }
+
+        .keyboard-activity {
+            height: 80px;
+            background: #f7fafc;
+            border-radius: 6px;
+            padding: 10px;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 11px;
+            overflow-y: auto;
+            border: 1px solid #e2e8f0;
+        }
+
+        .controls {
+            display: flex;
+            gap: 15px;
+            margin-bottom: 20px;
+            flex-wrap: wrap;
+        }
+
+        button {
+            padding: 12px 24px;
+            border: none;
+            border-radius: 6px;
+            background: #4299e1;
+            color: white;
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            transition: all 0.2s;
+        }
+
+        button:hover {
+            background: #3182ce;
+            transform: translateY(-1px);
+        }
+
+        button:active {
+            transform: translateY(0);
+        }
+
+        button.secondary {
+            background: #718096;
+        }
+
+        button.secondary:hover {
+            background: #4a5568;
+        }
+
+        .status-bar {
+            text-align: center;
+            padding: 15px;
+            background: #bee3f8;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            color: #2c5282;
+            font-weight: 500;
+        }
+
+        .activity-log {
+            height: 300px;
+            background: #1a202c;
+            color: #68d391;
+            padding: 20px;
+            border-radius: 8px;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 13px;
+            overflow-y: auto;
+            white-space: pre-wrap;
+            line-height: 1.4;
+        }
+
+        .timestamp {
+            color: #a0aec0;
+            font-size: 11px;
+        }
+
+        .key-display {
+            display: inline-block;
+            background: #2d3748;
+            color: white;
+            padding: 3px 8px;
+            border-radius: 4px;
+            font-family: monospace;
+            margin-right: 8px;
+            font-weight: bold;
+        }
+
+        .keyboard-count {
+            background: #4299e1;
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-weight: bold;
+            display: inline-block;
+            margin-left: 10px;
+        }
+
+        .progress-indicator {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+
+        .progress-step {
+            flex: 1;
+            text-align: center;
+            padding: 10px;
+            background: #e2e8f0;
+            border-radius: 6px;
+            font-weight: 500;
+            transition: all 0.3s;
+        }
+
+        .progress-step.completed {
+            background: #48bb78;
+            color: white;
+        }
+
+        .progress-step.current {
+            background: #4299e1;
+            color: white;
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.7; }
+        }
+
+        .scanning {
+            animation: pulse 1.5s infinite;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🎮 保育園タイピングゲーム</h1>
+        <p class="subtitle">みんなでたのしくタイピングをしよう！</p>
+
+        <div class="progress-indicator">
+            <div class="progress-step current">1.1 キーボード接続確認</div>
+            <div class="progress-step">1.2 プレイヤー集合</div>
+            <div class="progress-step">1.3 チーム作成</div>
+            <div class="progress-step">1.4 メンバー割り当て</div>
+            <div class="progress-step">1.5 キーボード割り当て</div>
+            <div class="progress-step">1.6 お題数設定</div>
+        </div>
+
+        <div class="status-bar" id="status">
+            キーボードを検知しています...
+        </div>
+
+        <div class="section">
+            <h3>
+                🎹 接続しているキーボード
+                <span class="keyboard-count" id="keyboard-count">0台</span>
+            </h3>
+            <p>ゲームで使用するキーボードがすべて接続されていることを確認してください。</p>
+            <div class="controls">
+                <button onclick="rescanKeyboards()">🔄 再スキャン</button>
+                <button onclick="testAllKeyboards()" class="secondary">⌨️ 全キーボードテスト</button>
+            </div>
+            <div class="keyboards-grid" id="keyboards-grid">
+                <!-- キーボードカードがここに表示されます -->
+            </div>
+        </div>
+
+        <div class="section">
+            <h3>📊 リアルタイム入力監視</h3>
+            <p>接続されたキーボードでタイピングして、正しく認識されるかテストしてください。</p>
+            <div class="controls">
+                <button onclick="clearActivityLog()">🗑️ ログクリア</button>
+                <button onclick="toggleMonitoring()" id="monitorBtn">⏸️ 監視停止</button>
+                <button onclick="exportLog()" class="secondary">📄 ログ保存</button>
+            </div>
+            <div class="activity-log" id="activity-log">
+=== キーボード入力監視開始 ===
+キーボードでタイピングしてテストしてください...
+
+            </div>
+        </div>
+
+        <div class="section" style="text-align: center;">
+            <h3>🚀 次のステップ</h3>
+            <p>すべてのキーボードが正しく認識されたら、次の段階に進みましょう。</p>
+            <button onclick="proceedToNextStep()" id="nextStepBtn" disabled style="font-size: 16px; padding: 15px 30px;">
+                1.2 プレイヤー集合へ進む
+            </button>
+        </div>
+    </div>
+
+    <script src="renderer.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -969,6 +969,19 @@
             キーボードを検知しています...
         </div>
 
+        <!-- 開発用プリセット（開発時のみ利用） -->
+        <div class="section" id="dev-preset-bar" style="border-left-color:#f59e0b;background:#fffbea;">
+            <h3>⚡ 開発プリセット</h3>
+            <p style="margin-top:0;color:#92400e">動作確認用の設定を素早く適用します（開発専用）</p>
+            <div class="controls">
+                <select id="devPresetSelect" class="form-input" style="max-width:360px">
+                    <option value="">プリセットを選択...</option>
+                </select>
+                <button id="applyDevPresetBtn">🚀 プリセット適用</button>
+            </div>
+            <div id="devPresetNote" style="font-size:12px;color:#92400e;margin-top:8px;display:none"></div>
+        </div>
+
         <div class="section">
             <h3>
                 🎹 接続しているキーボード

--- a/index.html
+++ b/index.html
@@ -410,6 +410,205 @@
         .hidden {
             display: none;
         }
+
+        /* チーム作成スタイル */
+        .team-creation-form {
+            background: #f0f8ff;
+            padding: 25px;
+            border-radius: 8px;
+            border: 2px dashed #4299e1;
+            margin-bottom: 20px;
+        }
+
+        .team-settings {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            align-items: end;
+        }
+
+        .radio-group {
+            display: flex;
+            gap: 15px;
+            margin-top: 5px;
+        }
+
+        .radio-option {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            cursor: pointer;
+            font-weight: normal;
+        }
+
+        .radio-option input[type="radio"] {
+            margin: 0;
+        }
+
+        .teams-display {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            margin: 20px 0;
+        }
+
+        .team-container {
+            background: white;
+            border-radius: 12px;
+            padding: 20px;
+            border: 3px solid;
+            position: relative;
+            min-height: 200px;
+        }
+
+        .team-container.team-1 { border-color: #ff6b6b; }
+        .team-container.team-2 { border-color: #4ecdc4; }
+        .team-container.team-3 { border-color: #45b7d1; }
+        .team-container.team-4 { border-color: #f9ca24; }
+
+        .team-header {
+            text-align: center;
+            margin-bottom: 20px;
+            padding-bottom: 10px;
+            border-bottom: 2px solid #e2e8f0;
+        }
+
+        .team-name {
+            font-size: 1.5em;
+            font-weight: bold;
+            margin-bottom: 5px;
+        }
+
+        .team-container.team-1 .team-name { color: #ff6b6b; }
+        .team-container.team-2 .team-name { color: #4ecdc4; }
+        .team-container.team-3 .team-name { color: #45b7d1; }
+        .team-container.team-4 .team-name { color: #f9ca24; }
+
+        .team-member-count {
+            font-size: 0.9em;
+            color: #666;
+        }
+
+        .team-members {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .team-member {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 10px;
+            background: #f8fafc;
+            border-radius: 6px;
+            border: 1px solid #e2e8f0;
+        }
+
+        .team-member-avatar {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-weight: bold;
+            font-size: 1.2em;
+        }
+
+        .team-member-name {
+            flex: 1;
+            font-weight: 500;
+        }
+
+        .team-member-actions {
+            display: flex;
+            gap: 5px;
+        }
+
+        .btn-mini {
+            padding: 4px 8px;
+            font-size: 10px;
+            border-radius: 3px;
+            cursor: pointer;
+        }
+
+        .drop-zone {
+            min-height: 60px;
+            border: 2px dashed #cbd5e0;
+            border-radius: 6px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #a0aec0;
+            font-style: italic;
+            margin-top: 10px;
+        }
+
+        .drop-zone.drag-over {
+            border-color: #4299e1;
+            background: #ebf8ff;
+            color: #4299e1;
+        }
+
+        .teams-summary {
+            background: #e6fffa;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .unassigned-players {
+            margin-top: 20px;
+            padding: 20px;
+            background: #fffbf0;
+            border-radius: 8px;
+            border: 2px dashed #f6ad55;
+        }
+
+        .unassigned-players h4 {
+            color: #c05621;
+            margin: 0 0 15px 0;
+        }
+
+        .unassigned-grid {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .unassigned-player {
+            background: white;
+            padding: 10px 15px;
+            border-radius: 6px;
+            border: 1px solid #f6ad55;
+            cursor: move;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            transition: all 0.2s;
+        }
+
+        .unassigned-player:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        .unassigned-player-avatar {
+            width: 30px;
+            height: 30px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-weight: bold;
+            font-size: 0.9em;
+        }
     </style>
 </head>
 <body>
@@ -506,6 +705,62 @@
             <!-- プレイヤー一覧 -->
             <div class="players-grid" id="players-grid">
                 <!-- プレイヤーカードがここに表示されます -->
+            </div>
+        </div>
+
+        <!-- 1.3 チーム作成セクション -->
+        <div class="section hidden" id="teams-section">
+            <h3>🏆 チーム作成</h3>
+            <p>友達をチームに分けて、楽しく競い合いましょう！</p>
+
+            <!-- チーム作成設定 -->
+            <div class="team-creation-form">
+                <h4>チーム設定</h4>
+                <div class="team-settings">
+                    <div class="form-group">
+                        <label for="teamCount">チーム数</label>
+                        <select id="teamCount" class="form-input" onchange="updateTeamCount()">
+                            <option value="2">2チーム</option>
+                            <option value="3">3チーム</option>
+                            <option value="4">4チーム</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label>分割方法</label>
+                        <div class="radio-group">
+                            <label class="radio-option">
+                                <input type="radio" name="divisionMethod" value="auto" checked onchange="updateDivisionMethod()">
+                                <span>自動で分ける</span>
+                            </label>
+                            <label class="radio-option">
+                                <input type="radio" name="divisionMethod" value="manual" onchange="updateDivisionMethod()">
+                                <span>手動で分ける</span>
+                            </label>
+                        </div>
+                    </div>
+                    <div class="controls">
+                        <button onclick="generateTeams()" id="generateTeamsBtn">🎲 チーム自動生成</button>
+                        <button onclick="clearTeams()" class="secondary">🗑️ チームリセット</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- チーム表示エリア -->
+            <div class="teams-display" id="teams-display">
+                <!-- チームがここに表示されます -->
+            </div>
+
+            <!-- チーム作成完了 -->
+            <div class="teams-summary" id="teams-summary" style="display: none;">
+                <div>
+                    <strong>チーム作成完了！</strong>
+                    <div style="font-size: 0.9em; color: #666;">すべての友達がチームに参加しました</div>
+                </div>
+                <div>
+                    <button onclick="proceedToMemberAssignment()" id="proceedToMemberBtn" disabled>
+                        1.4 メンバー割り当てへ進む
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -819,6 +819,136 @@
             font-family: 'Monaco', 'Menlo', monospace;
             font-weight: bold;
         }
+
+        /* 同時進行ゲーム用スタイル */
+        .teams-game-display {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
+            gap: 30px;
+            margin-bottom: 40px;
+        }
+
+        .team-game-card {
+            background: white;
+            border: 4px solid;
+            border-radius: 16px;
+            padding: 25px;
+            box-shadow: 0 8px 25px rgba(0,0,0,0.1);
+            transition: all 0.3s;
+        }
+
+        .team-game-card.team-1 { border-color: #ff6b6b; }
+        .team-game-card.team-2 { border-color: #4ecdc4; }
+        .team-game-card.team-3 { border-color: #45b7d1; }
+        .team-game-card.team-4 { border-color: #f9ca24; }
+
+        .team-game-card.finished {
+            opacity: 0.7;
+            background: #f0f0f0;
+        }
+
+        .team-game-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 20px;
+            padding-bottom: 15px;
+            border-bottom: 2px solid #e2e8f0;
+        }
+
+        .team-game-name {
+            font-size: 1.5em;
+            font-weight: bold;
+        }
+
+        .team-game-card.team-1 .team-game-name { color: #ff6b6b; }
+        .team-game-card.team-2 .team-game-name { color: #4ecdc4; }
+        .team-game-card.team-3 .team-game-name { color: #45b7d1; }
+        .team-game-card.team-4 .team-game-name { color: #f9ca24; }
+
+        .team-current-player {
+            background: rgba(66, 153, 225, 0.2);
+            padding: 8px 15px;
+            border-radius: 20px;
+            font-size: 0.9em;
+            font-weight: bold;
+        }
+
+        .team-word-display {
+            background: #f8f9fa;
+            padding: 25px;
+            border-radius: 12px;
+            margin-bottom: 20px;
+            text-align: center;
+            border: 2px solid #e9ecef;
+        }
+
+        .team-word-original {
+            font-size: 2.2em;
+            font-weight: bold;
+            color: #2d3748;
+            margin-bottom: 8px;
+            font-family: serif;
+        }
+
+        .team-word-romaji {
+            font-size: 1.8em;
+            color: #4299e1;
+            margin-bottom: 15px;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-weight: bold;
+        }
+
+        .team-word-progress {
+            font-size: 1.5em;
+            font-family: 'Monaco', 'Menlo', monospace;
+            padding: 10px;
+            background: white;
+            border-radius: 8px;
+            border: 1px solid #cbd5e0;
+        }
+
+        .team-typed-part {
+            background: #48bb78;
+            color: white;
+            padding: 3px 6px;
+            border-radius: 4px;
+        }
+
+        .team-remaining-part {
+            color: #a0aec0;
+        }
+
+        .team-score-info {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: rgba(0,0,0,0.02);
+            padding: 15px;
+            border-radius: 8px;
+        }
+
+        .team-completed-count {
+            font-size: 1.2em;
+            font-weight: bold;
+        }
+
+        .team-status {
+            font-weight: bold;
+            padding: 5px 12px;
+            border-radius: 15px;
+            font-size: 0.9em;
+        }
+
+        .team-status.playing {
+            background: #48bb78;
+            color: white;
+        }
+
+        .team-status.finished {
+            background: #ed8936;
+            color: white;
+        }
     </style>
 </head>
 <body>
@@ -976,29 +1106,11 @@
 
         <!-- Phase 2: ゲームフェーズ -->
         <div class="section hidden" id="game-section">
-            <h3>🎮 ゲーム進行中</h3>
+            <h3>🎮 同時進行ゲーム中</h3>
 
-            <!-- 現在のターン表示 -->
-            <div class="current-turn-display" id="current-turn">
-                <div class="turn-header">
-                    <h4>現在のターン</h4>
-                    <div class="turn-info">
-                        <span class="current-team" id="current-team-name">チーム A</span>
-                        <span class="current-player" id="current-player-name">たろう くん</span>
-                    </div>
-                </div>
-            </div>
-
-            <!-- お題表示エリア -->
-            <div class="word-display-container">
-                <div class="word-display" id="word-display">
-                    <div class="word-original" id="word-original">りんご</div>
-                    <div class="word-romaji" id="word-romaji">ringo</div>
-                    <div class="word-progress" id="word-progress">
-                        <span class="typed-part" id="typed-part"></span>
-                        <span class="remaining-part" id="remaining-part">ringo</span>
-                    </div>
-                </div>
+            <!-- 各チームの状態表示 -->
+            <div class="teams-game-display" id="teams-game-display">
+                <!-- 各チーム別のゲーム状態 -->
             </div>
 
             <!-- 各チームの進捗表示 -->

--- a/index.html
+++ b/index.html
@@ -609,6 +609,216 @@
             font-weight: bold;
             font-size: 0.9em;
         }
+
+        /* Phase 2: ゲームフェーズスタイル */
+        .current-turn-display {
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            padding: 25px;
+            border-radius: 12px;
+            margin-bottom: 30px;
+            text-align: center;
+        }
+
+        .turn-header h4 {
+            margin: 0 0 15px 0;
+            font-size: 1.8em;
+            font-weight: bold;
+        }
+
+        .turn-info {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            gap: 20px;
+            flex-wrap: wrap;
+        }
+
+        .current-team, .current-player {
+            background: rgba(255, 255, 255, 0.2);
+            padding: 10px 20px;
+            border-radius: 20px;
+            font-weight: bold;
+            font-size: 1.2em;
+        }
+
+        .word-display-container {
+            display: flex;
+            justify-content: center;
+            margin-bottom: 40px;
+        }
+
+        .word-display {
+            background: white;
+            padding: 40px;
+            border-radius: 16px;
+            box-shadow: 0 8px 32px rgba(0,0,0,0.1);
+            text-align: center;
+            border: 4px solid #4299e1;
+            min-width: 400px;
+        }
+
+        .word-original {
+            font-size: 3em;
+            font-weight: bold;
+            color: #2d3748;
+            margin-bottom: 10px;
+            font-family: serif;
+        }
+
+        .word-romaji {
+            font-size: 2.5em;
+            color: #4299e1;
+            margin-bottom: 20px;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-weight: bold;
+        }
+
+        .word-progress {
+            font-size: 2em;
+            font-family: 'Monaco', 'Menlo', monospace;
+            margin-top: 20px;
+            padding: 15px;
+            background: #f7fafc;
+            border-radius: 8px;
+            border: 2px solid #e2e8f0;
+        }
+
+        .typed-part {
+            background: #48bb78;
+            color: white;
+            padding: 5px;
+            border-radius: 4px;
+        }
+
+        .remaining-part {
+            color: #a0aec0;
+        }
+
+        .teams-progress {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            margin-bottom: 30px;
+        }
+
+        .team-progress-card {
+            background: white;
+            padding: 20px;
+            border-radius: 12px;
+            border: 3px solid;
+            text-align: center;
+            transition: all 0.3s;
+        }
+
+        .team-progress-card.team-1 { border-color: #ff6b6b; }
+        .team-progress-card.team-2 { border-color: #4ecdc4; }
+        .team-progress-card.team-3 { border-color: #45b7d1; }
+        .team-progress-card.team-4 { border-color: #f9ca24; }
+
+        .team-progress-card.active {
+            transform: scale(1.05);
+            box-shadow: 0 8px 25px rgba(0,0,0,0.15);
+        }
+
+        .team-progress-header {
+            font-size: 1.5em;
+            font-weight: bold;
+            margin-bottom: 15px;
+        }
+
+        .team-progress-card.team-1 .team-progress-header { color: #ff6b6b; }
+        .team-progress-card.team-2 .team-progress-header { color: #4ecdc4; }
+        .team-progress-card.team-3 .team-progress-header { color: #45b7d1; }
+        .team-progress-card.team-4 .team-progress-header { color: #f9ca24; }
+
+        .progress-bar {
+            width: 100%;
+            height: 20px;
+            background: #e2e8f0;
+            border-radius: 10px;
+            overflow: hidden;
+            margin: 10px 0;
+        }
+
+        .progress-fill {
+            height: 100%;
+            background: linear-gradient(90deg, #48bb78 0%, #68d391 100%);
+            transition: width 0.5s ease;
+            border-radius: 10px;
+        }
+
+        .progress-text {
+            font-weight: bold;
+            color: #2d3748;
+            margin-top: 5px;
+        }
+
+        .game-controls {
+            display: flex;
+            justify-content: center;
+            gap: 20px;
+            margin-top: 30px;
+        }
+
+        /* Phase 3: 結果フェーズスタイル */
+        .result-display {
+            background: linear-gradient(135deg, #ffd89b 0%, #19547b 100%);
+            color: white;
+            padding: 40px;
+            border-radius: 16px;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+
+        .winner-announcement {
+            font-size: 2.5em;
+            font-weight: bold;
+            margin-bottom: 30px;
+            animation: bounce 1s infinite alternate;
+        }
+
+        @keyframes bounce {
+            0% { transform: translateY(0); }
+            100% { transform: translateY(-10px); }
+        }
+
+        .results-table {
+            background: white;
+            color: #2d3748;
+            border-radius: 12px;
+            padding: 20px;
+            margin-top: 20px;
+        }
+
+        .result-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 15px;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .result-row:last-child {
+            border-bottom: none;
+        }
+
+        .result-position {
+            font-size: 1.5em;
+            font-weight: bold;
+            width: 60px;
+        }
+
+        .result-team {
+            flex: 1;
+            text-align: left;
+            font-weight: bold;
+        }
+
+        .result-time {
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-weight: bold;
+        }
     </style>
 </head>
 <body>
@@ -763,8 +973,62 @@
                 </div>
             </div>
         </div>
+
+        <!-- Phase 2: ゲームフェーズ -->
+        <div class="section hidden" id="game-section">
+            <h3>🎮 ゲーム進行中</h3>
+
+            <!-- 現在のターン表示 -->
+            <div class="current-turn-display" id="current-turn">
+                <div class="turn-header">
+                    <h4>現在のターン</h4>
+                    <div class="turn-info">
+                        <span class="current-team" id="current-team-name">チーム A</span>
+                        <span class="current-player" id="current-player-name">たろう くん</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- お題表示エリア -->
+            <div class="word-display-container">
+                <div class="word-display" id="word-display">
+                    <div class="word-original" id="word-original">りんご</div>
+                    <div class="word-romaji" id="word-romaji">ringo</div>
+                    <div class="word-progress" id="word-progress">
+                        <span class="typed-part" id="typed-part"></span>
+                        <span class="remaining-part" id="remaining-part">ringo</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 各チームの進捗表示 -->
+            <div class="teams-progress" id="teams-progress">
+                <!-- チームプログレス表示 -->
+            </div>
+
+            <!-- ゲーム制御 -->
+            <div class="game-controls">
+                <button onclick="pauseGame()" id="pauseGameBtn" class="secondary">⏸️ 一時停止</button>
+                <button onclick="resetGame()" class="btn-danger">🔄 ゲームリセット</button>
+            </div>
+        </div>
+
+        <!-- Phase 3: 結果フェーズ -->
+        <div class="section hidden" id="result-section">
+            <h3>🏆 ゲーム結果</h3>
+
+            <div class="result-display" id="result-display">
+                <!-- 結果表示 -->
+            </div>
+
+            <div class="game-controls">
+                <button onclick="restartGame()" id="restartGameBtn">🆕 新しいゲーム</button>
+                <button onclick="backToSetup()" class="secondary">⚙️ 設定に戻る</button>
+            </div>
+        </div>
     </div>
 
+    <script src="words.js"></script>
     <script src="renderer.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -276,6 +276,140 @@
         .scanning {
             animation: pulse 1.5s infinite;
         }
+
+        /* プレイヤー管理スタイル */
+        .players-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+            gap: 20px;
+            margin-top: 20px;
+        }
+
+        .player-card {
+            background: white;
+            padding: 20px;
+            border-radius: 8px;
+            border: 2px solid #e2e8f0;
+            text-align: center;
+            transition: all 0.3s;
+        }
+
+        .player-card:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+
+        .player-avatar {
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            margin: 0 auto 15px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 2em;
+            font-weight: bold;
+        }
+
+        .player-name {
+            font-size: 1.1em;
+            font-weight: bold;
+            color: #2d3748;
+            margin-bottom: 10px;
+        }
+
+        .player-actions {
+            display: flex;
+            gap: 10px;
+            justify-content: center;
+        }
+
+        .btn-small {
+            padding: 6px 12px;
+            font-size: 12px;
+            border-radius: 4px;
+        }
+
+        .btn-danger {
+            background: #f56565;
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background: #e53e3e;
+        }
+
+        .add-player-form {
+            background: #f0f8ff;
+            padding: 25px;
+            border-radius: 8px;
+            border: 2px dashed #4299e1;
+            text-align: center;
+            margin-bottom: 20px;
+        }
+
+        .form-group {
+            margin-bottom: 15px;
+        }
+
+        .form-group label {
+            display: block;
+            margin-bottom: 5px;
+            font-weight: bold;
+            color: #2d3748;
+        }
+
+        .form-input {
+            width: 100%;
+            max-width: 300px;
+            padding: 12px;
+            border: 2px solid #e2e8f0;
+            border-radius: 6px;
+            font-size: 16px;
+            transition: border-color 0.3s;
+        }
+
+        .form-input:focus {
+            outline: none;
+            border-color: #4299e1;
+        }
+
+        .camera-placeholder {
+            width: 150px;
+            height: 150px;
+            border-radius: 50%;
+            background: #f7fafc;
+            border: 3px dashed #cbd5e0;
+            margin: 0 auto 20px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #a0aec0;
+            font-size: 3em;
+            cursor: pointer;
+            transition: all 0.3s;
+        }
+
+        .camera-placeholder:hover {
+            border-color: #4299e1;
+            color: #4299e1;
+        }
+
+        .players-summary {
+            background: #e6fffa;
+            padding: 15px;
+            border-radius: 6px;
+            margin-bottom: 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .hidden {
+            display: none;
+        }
     </style>
 </head>
 <body>
@@ -284,12 +418,12 @@
         <p class="subtitle">みんなでたのしくタイピングをしよう！</p>
 
         <div class="progress-indicator">
-            <div class="progress-step current">1.1 キーボード接続確認</div>
-            <div class="progress-step">1.2 プレイヤー集合</div>
-            <div class="progress-step">1.3 チーム作成</div>
-            <div class="progress-step">1.4 メンバー割り当て</div>
-            <div class="progress-step">1.5 キーボード割り当て</div>
-            <div class="progress-step">1.6 お題数設定</div>
+            <div class="progress-step" id="phase-1-1">1.1 キーボード接続確認</div>
+            <div class="progress-step" id="phase-1-2">1.2 プレイヤー集合</div>
+            <div class="progress-step" id="phase-1-3">1.3 チーム作成</div>
+            <div class="progress-step" id="phase-1-4">1.4 メンバー割り当て</div>
+            <div class="progress-step" id="phase-1-5">1.5 キーボード割り当て</div>
+            <div class="progress-step" id="phase-1-6">1.6 お題数設定</div>
         </div>
 
         <div class="status-bar" id="status">
@@ -326,12 +460,53 @@
             </div>
         </div>
 
-        <div class="section" style="text-align: center;">
+        <!-- 1.1 キーボード接続確認セクション -->
+        <div class="section" style="text-align: center;" id="keyboard-section">
             <h3>🚀 次のステップ</h3>
             <p>すべてのキーボードが正しく認識されたら、次の段階に進みましょう。</p>
             <button onclick="proceedToNextStep()" id="nextStepBtn" disabled style="font-size: 16px; padding: 15px 30px;">
                 1.2 プレイヤー集合へ進む
             </button>
+        </div>
+
+        <!-- 1.2 プレイヤー集合セクション -->
+        <div class="section hidden" id="players-section">
+            <h3>👥 プレイヤー集合</h3>
+            <p>ゲームに参加する友達の名前を入力して、みんなを集めましょう！</p>
+
+            <!-- プレイヤー追加フォーム -->
+            <div class="add-player-form">
+                <h4>新しい友達を追加</h4>
+                <div class="camera-placeholder" onclick="takePhoto()" title="将来的には写真撮影機能">
+                    📷
+                </div>
+                <div class="form-group">
+                    <label for="playerName">なまえ</label>
+                    <input type="text" id="playerName" class="form-input" placeholder="ともだちのなまえをいれてね" maxlength="10">
+                </div>
+                <div class="controls">
+                    <button onclick="addPlayer()" id="addPlayerBtn">➕ ともだちを追加</button>
+                    <button onclick="clearAllPlayers()" class="secondary">🗑️ みんなクリア</button>
+                </div>
+            </div>
+
+            <!-- プレイヤー数サマリー -->
+            <div class="players-summary">
+                <div>
+                    <strong>参加者数: <span id="playerCount">0</span>人</strong>
+                    <div style="font-size: 0.9em; color: #666;">最低2人以上必要です</div>
+                </div>
+                <div>
+                    <button onclick="proceedToTeamCreation()" id="proceedToTeamsBtn" disabled>
+                        1.3 チーム作成へ進む
+                    </button>
+                </div>
+            </div>
+
+            <!-- プレイヤー一覧 -->
+            <div class="players-grid" id="players-grid">
+                <!-- プレイヤーカードがここに表示されます -->
+            </div>
         </div>
     </div>
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,8 @@ module.exports = {
       roots: ['<rootDir>/src'],
       testMatch: [
         '<rootDir>/src/__tests__/**/*.simple.test.ts',
-        '<rootDir>/src/demo/__tests__/*.simple.test.ts'
+        '<rootDir>/src/demo/__tests__/*.simple.test.ts',
+        '<rootDir>/src/domain/**/*.spec.ts'
       ],
       transform: {
         '^.+\\.ts$': 'ts-jest'

--- a/main.js
+++ b/main.js
@@ -1,0 +1,281 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+
+// Native Addonを使ってキーボード検知
+let keyboardDetector;
+try {
+    const { KeyboardDetector } = require('./native-keyboard-addon/index.js');
+    keyboardDetector = new KeyboardDetector();
+    console.log('Native keyboard detector loaded successfully');
+} catch (error) {
+    console.warn('Native keyboard detector not available, using mock data:', error.message);
+}
+
+class KeyboardGameApp {
+    constructor() {
+        this.mainWindow = null;
+        this.detectedKeyboards = [];
+        this.inputHistory = [];
+        this.keyboardUpdateCallbacks = [];
+    }
+
+    async createWindow() {
+        this.mainWindow = new BrowserWindow({
+            width: 1400,
+            height: 900,
+            webPreferences: {
+                nodeIntegration: false,
+                contextIsolation: true,
+                preload: path.join(__dirname, 'preload.js')
+            },
+            title: 'Keyboard Game - 保育園タイピングゲーム'
+        });
+
+        await this.mainWindow.loadFile('index.html');
+
+        // 開発時はDevToolsを開く
+        if (process.argv.includes('--dev')) {
+            this.mainWindow.webContents.openDevTools();
+        }
+
+        this.setupKeyboardDetection();
+        this.setupInputHandling();
+        this.setupRealKeyboardInput();
+    }
+
+    setupKeyboardDetection() {
+        console.log('=== キーボード検知開始 ===');
+
+        try {
+            if (keyboardDetector) {
+                // Native Addonによるキーボード検知
+                console.log('Native Addonでキーボード検知を初期化...');
+                const initialized = keyboardDetector.initialize();
+
+                if (initialized) {
+                    console.log('Native Addon初期化成功、キーボードスキャン開始...');
+                    this.scanKeyboards();
+
+                    // 定期的にキーボード状態をチェック（新しいキーボードの検知）
+                    setInterval(() => {
+                        this.scanKeyboards();
+                    }, 3000); // 3秒ごと
+                } else {
+                    console.error('Native Addon初期化失敗');
+                    throw new Error('Native Addon initialization failed');
+                }
+            } else {
+                throw new Error('Native keyboard detector not available');
+            }
+        } catch (error) {
+            console.error('キーボード検知エラー:', error);
+            // フォールバック: モックデータ
+            this.detectedKeyboards = [
+                {
+                    id: 'kb-1',
+                    name: 'Mock Keyboard 1',
+                    manufacturer: 'Mock Inc.',
+                    vendorId: 0x1234,
+                    productId: 0x5678,
+                    locationId: 0x01,
+                    connected: true,
+                    method: 'mock'
+                },
+                {
+                    id: 'kb-2',
+                    name: 'Mock Keyboard 2',
+                    manufacturer: 'Mock Corp.',
+                    vendorId: 0x9ABC,
+                    productId: 0xDEF0,
+                    locationId: 0x02,
+                    connected: true,
+                    method: 'mock'
+                }
+            ];
+            console.log('フォールバック: モックデータ使用');
+        }
+
+        // レンダラーにキーボード情報を送信
+        this.sendToRenderer('keyboards-detected', this.detectedKeyboards);
+    }
+
+    scanKeyboards() {
+        if (!keyboardDetector) return;
+
+        try {
+            const detectedKeyboards = keyboardDetector.scanKeyboards();
+
+            // 前回との差分チェック（LocationIDベースで重複除去）
+            const previousCount = this.detectedKeyboards.length;
+            const existingLocationIds = new Set(this.detectedKeyboards.map(kb => kb.locationId));
+
+            // 新しいキーボードリストを作成（重複除去）
+            const newKeyboards = detectedKeyboards.map((device, index) => ({
+                id: `kb-${index + 1}`,
+                name: device.name || `Keyboard ${index + 1}`,
+                manufacturer: device.manufacturer || 'Unknown',
+                vendorId: device.vendorId,
+                productId: device.productId,
+                locationId: device.locationId,
+                connected: true,
+                method: 'native-addon'
+            }));
+
+            // LocationIDで重複除去
+            const uniqueKeyboards = [];
+            const seenLocationIds = new Set();
+
+            for (const keyboard of newKeyboards) {
+                if (!seenLocationIds.has(keyboard.locationId)) {
+                    seenLocationIds.add(keyboard.locationId);
+                    uniqueKeyboards.push(keyboard);
+                }
+            }
+
+            this.detectedKeyboards = uniqueKeyboards;
+
+            // キーボード数が変更された場合のみ通知
+            if (this.detectedKeyboards.length !== previousCount) {
+                console.log(`キーボード数変更: ${previousCount} -> ${this.detectedKeyboards.length}`);
+                this.sendToRenderer('keyboards-updated', this.detectedKeyboards);
+            }
+
+        } catch (error) {
+            console.error('キーボードスキャンエラー:', error);
+        }
+    }
+
+    setupRealKeyboardInput() {
+        console.log('=== リアルキーボード入力監視設定 ===');
+
+        if (!keyboardDetector) {
+            console.warn('Native keyboard detector not available, skipping real input setup');
+            return;
+        }
+
+        try {
+            // Native Addonによる直接キーイベントキャプチャ
+            const success = keyboardDetector.setKeyEventCallback((keyEvent) => {
+                console.log(`🎹 Real Input - KB-${keyEvent.keyboardId}: "${keyEvent.keyName}"`);
+
+                // 正確なキーボードIDを含むイベントを送信
+                const realKeyEvent = {
+                    key: keyEvent.keyName,
+                    code: keyEvent.keyName,
+                    keyboardId: `kb-${keyEvent.keyboardId}`,
+                    timestamp: Date.now(),
+                    source: 'native-direct',
+                    rawData: {
+                        usagePage: keyEvent.usagePage,
+                        usage: keyEvent.usage,
+                        value: keyEvent.value,
+                        nativeTimestamp: keyEvent.timestamp
+                    }
+                };
+
+                // 入力履歴に追加
+                this.inputHistory.push(realKeyEvent);
+                if (this.inputHistory.length > 100) {
+                    this.inputHistory.shift();
+                }
+
+                // レンダラーに送信
+                this.sendToRenderer('real-key-input', realKeyEvent);
+            });
+
+            if (success) {
+                console.log('✅ リアルキーボード入力監視が開始されました');
+            } else {
+                console.error('❌ リアルキーボード入力監視の開始に失敗');
+            }
+        } catch (error) {
+            console.error('リアルキーボード入力設定エラー:', error);
+        }
+    }
+
+    setupInputHandling() {
+        // Electronの入力イベント監視（フォールバック用）
+        this.mainWindow.webContents.on('before-input-event', (event, input) => {
+            if (input.type === 'keyDown') {
+                // Native Addonが利用可能でない場合のフォールバック
+                if (!keyboardDetector) {
+                    this.handleFallbackKeyInput(input);
+                }
+            }
+        });
+    }
+
+    handleFallbackKeyInput(input) {
+        const keyEvent = {
+            key: input.key,
+            code: input.code,
+            keyboardId: 'kb-1', // フォールバック時は仮のID
+            timestamp: Date.now(),
+            source: 'electron-fallback',
+            modifiers: {
+                shift: input.shift,
+                control: input.control,
+                alt: input.alt,
+                meta: input.meta
+            }
+        };
+
+        console.log(`⌨️ Fallback Input: "${input.key}"`);
+
+        // 入力履歴に追加
+        this.inputHistory.push(keyEvent);
+        if (this.inputHistory.length > 100) {
+            this.inputHistory.shift();
+        }
+
+        // レンダラーに送信
+        this.sendToRenderer('key-input', keyEvent);
+    }
+
+    sendToRenderer(channel, data) {
+        if (this.mainWindow) {
+            this.mainWindow.webContents.send(channel, data);
+        }
+    }
+
+    // IPCハンドラー
+    setupIPC() {
+        ipcMain.handle('get-keyboards', () => {
+            return this.detectedKeyboards;
+        });
+
+        ipcMain.handle('get-input-history', () => {
+            return this.inputHistory;
+        });
+
+        ipcMain.handle('clear-history', () => {
+            this.inputHistory = [];
+            return { success: true };
+        });
+
+        ipcMain.handle('rescan-keyboards', () => {
+            this.scanKeyboards();
+            return this.detectedKeyboards;
+        });
+    }
+}
+
+// Electronアプリケーション初期化
+const keyboardGameApp = new KeyboardGameApp();
+
+app.whenReady().then(() => {
+    keyboardGameApp.setupIPC();
+    keyboardGameApp.createWindow();
+});
+
+app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+        app.quit();
+    }
+});
+
+app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+        keyboardGameApp.createWindow();
+    }
+});

--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ class KeyboardGameApp {
             title: 'Keyboard Game - 保育園タイピングゲーム'
         });
 
+        // Load the current main UI (new UI)
         await this.mainWindow.loadFile('index.html');
 
         // 開発時はDevToolsを開く

--- a/native-keyboard-addon/binding.gyp
+++ b/native-keyboard-addon/binding.gyp
@@ -1,0 +1,45 @@
+{
+  "targets": [
+    {
+      "target_name": "keyboard_detector",
+      "sources": [],
+      "conditions": [
+        ["OS=='mac'", {
+          "sources": [
+            "src/keyboard_detector_mac.mm"
+          ],
+          "link_settings": {
+            "libraries": [
+              "-framework IOKit",
+              "-framework Foundation",
+              "-framework AppKit"
+            ]
+          },
+          "xcode_settings": {
+            "CLANG_CXX_LIBRARY": "libc++",
+            "MACOSX_DEPLOYMENT_TARGET": "10.14",
+            "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+          }
+        }],
+        ["OS=='win'", {
+          "sources": [
+            "src/keyboard_detector_win.cpp"
+          ],
+          "libraries": [
+            "user32.lib"
+          ]
+        }],
+        ["OS=='linux'", {
+          "sources": [
+            "src/keyboard_detector_linux.cpp"
+          ]
+        }]
+      ],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "dependencies": [],
+      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"]
+    }
+  ]
+}

--- a/native-keyboard-addon/index.js
+++ b/native-keyboard-addon/index.js
@@ -1,0 +1,192 @@
+const path = require('path');
+const os = require('os');
+
+let nativeAddon;
+
+try {
+    // プラットフォーム別のネイティブアドオンをロード
+    const platform = os.platform();
+    const addonPath = path.join(__dirname, 'build', 'Release', 'keyboard_detector.node');
+
+    console.log(`Loading native addon for platform: ${platform}`);
+    console.log(`Addon path: ${addonPath}`);
+
+    nativeAddon = require(addonPath);
+    console.log('Native addon loaded successfully');
+
+} catch (error) {
+    console.error('Failed to load native addon:', error.message);
+    console.error('Build the addon with: npm run build');
+
+    // フォールバック: ダミー実装
+    nativeAddon = {
+        initialize: () => {
+            console.log('Using fallback implementation - native addon not available');
+            return false;
+        },
+        scanKeyboards: () => {
+            console.log('Fallback: No keyboards detected');
+            return [];
+        },
+        getKeyboardCount: () => {
+            console.log('Fallback: 0 keyboards');
+            return 0;
+        }
+    };
+}
+
+class KeyboardDetector {
+    constructor() {
+        this.initialized = false;
+        this.keyEventCallback = null;
+    }
+
+    /**
+     * IOHIDManagerを初期化
+     * @returns {boolean} 初期化成功
+     */
+    initialize() {
+        try {
+            console.log('Initializing keyboard detector...');
+            this.initialized = nativeAddon.initialize();
+            console.log(`Initialization ${this.initialized ? 'successful' : 'failed'}`);
+            return this.initialized;
+        } catch (error) {
+            console.error('Error during initialization:', error);
+            return false;
+        }
+    }
+
+    /**
+     * 接続されているキーボードをスキャン
+     * @returns {Array} キーボード情報の配列
+     */
+    scanKeyboards() {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return [];
+        }
+
+        try {
+            console.log('Scanning for keyboards...');
+            const keyboards = nativeAddon.scanKeyboards();
+            console.log(`Found ${keyboards.length} keyboard(s)`);
+
+            keyboards.forEach((kbd, index) => {
+                console.log(`Keyboard ${index + 1}:`);
+                console.log(`  Name: ${kbd.name}`);
+                console.log(`  Manufacturer: ${kbd.manufacturer}`);
+                console.log(`  Vendor ID: 0x${kbd.vendorId.toString(16)}`);
+                console.log(`  Product ID: 0x${kbd.productId.toString(16)}`);
+                console.log(`  Location ID: 0x${kbd.locationId.toString(16)}`);
+            });
+
+            return keyboards;
+        } catch (error) {
+            console.error('Error during keyboard scan:', error);
+            return [];
+        }
+    }
+
+    /**
+     * 検知されたキーボード数を取得
+     * @returns {number} キーボード数
+     */
+    getKeyboardCount() {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return 0;
+        }
+
+        try {
+            const count = nativeAddon.getKeyboardCount();
+            console.log(`Total keyboards: ${count}`);
+            return count;
+        } catch (error) {
+            console.error('Error getting keyboard count:', error);
+            return 0;
+        }
+    }
+
+    /**
+     * キーイベントのコールバック関数を設定
+     * @param {function} callback キーイベントを受け取るコールバック関数
+     */
+    setKeyEventCallback(callback) {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return false;
+        }
+
+        try {
+            this.keyEventCallback = callback;
+            const success = nativeAddon.setKeyEventCallback(callback);
+            console.log(`Key event callback ${success ? 'registered' : 'failed to register'}`);
+            return success;
+        } catch (error) {
+            console.error('Error setting key event callback:', error);
+            return false;
+        }
+    }
+
+    /**
+     * キューから次のキーイベントを取得（ポーリング用）
+     * @returns {Object|null} キーイベントオブジェクト、またはnull
+     */
+    getNextKeyEvent() {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return null;
+        }
+
+        try {
+            return nativeAddon.getNextKeyEvent();
+        } catch (error) {
+            console.error('Error getting next key event:', error);
+            return null;
+        }
+    }
+
+    /**
+     * キーイベントのポーリングを開始
+     * @param {function} callback キーイベントを受け取るコールバック関数
+     * @param {number} intervalMs ポーリング間隔（ミリ秒）
+     */
+    startKeyEventPolling(callback, intervalMs = 10) {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return null;
+        }
+
+        const pollInterval = setInterval(() => {
+            const keyEvent = this.getNextKeyEvent();
+            if (keyEvent) {
+                callback(keyEvent);
+            }
+        }, intervalMs);
+
+        console.log(`Key event polling started (interval: ${intervalMs}ms)`);
+        return pollInterval;
+    }
+
+    /**
+     * キーイベントのポーリングを停止
+     * @param {number} pollInterval startKeyEventPollingから返されたinterval ID
+     */
+    stopKeyEventPolling(pollInterval) {
+        if (pollInterval) {
+            clearInterval(pollInterval);
+            console.log('Key event polling stopped');
+        }
+    }
+}
+
+module.exports = {
+    KeyboardDetector,
+    // 直接関数のエクスポートも提供
+    initialize: () => nativeAddon.initialize(),
+    scanKeyboards: () => nativeAddon.scanKeyboards(),
+    getKeyboardCount: () => nativeAddon.getKeyboardCount(),
+    setKeyEventCallback: (callback) => nativeAddon.setKeyEventCallback(callback),
+    getNextKeyEvent: () => nativeAddon.getNextKeyEvent()
+};

--- a/native-keyboard-addon/package-lock.json
+++ b/native-keyboard-addon/package-lock.json
@@ -1,0 +1,1274 @@
+{
+  "name": "native-keyboard-detector",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "native-keyboard-detector",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0"
+      },
+      "devDependencies": {
+        "node-gyp": "^10.0.1"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+      "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+      "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^2.0.0",
+        "cacache": "^18.0.0",
+        "http-cache-semantics": "^4.1.1",
+        "is-lambda": "^1.0.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+      "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
+      "integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^13.0.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^4.1.0",
+        "semver": "^7.3.5",
+        "tar": "^6.2.1",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+      "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/native-keyboard-addon/package.json
+++ b/native-keyboard-addon/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "native-keyboard-detector",
+  "version": "1.0.0",
+  "description": "Native keyboard detection addon for Electron apps",
+  "main": "index.js",
+  "scripts": {
+    "build": "node-gyp rebuild",
+    "clean": "node-gyp clean",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "node-addon-api": "^7.0.0"
+  },
+  "devDependencies": {
+    "node-gyp": "^10.0.1"
+  },
+  "gypfile": true,
+  "author": "Takatomo Ezo",
+  "license": "MIT"
+}

--- a/native-keyboard-addon/src/keyboard_detector_mac.mm
+++ b/native-keyboard-addon/src/keyboard_detector_mac.mm
@@ -1,0 +1,550 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import <IOKit/hid/IOHIDManager.h>
+#import <IOKit/hid/IOHIDKeys.h>
+#import <IOKit/hid/IOHIDValue.h>
+#import <IOKit/hid/IOHIDElement.h>
+#include <node_api.h>
+#include <uv.h>
+#include <vector>
+#include <map>
+#include <string>
+#include <iostream>
+#include <queue>
+#include <memory>
+#include <thread>
+#include <mutex>
+
+struct KeyboardDevice {
+    std::string name;
+    std::string manufacturer;
+    uint32_t vendorId;
+    uint32_t productId;
+    uint32_t locationId;
+    IOHIDDeviceRef device;
+    int keyboardId;  // 識別用ID
+};
+
+struct KeyEvent {
+    int keyboardId;
+    uint32_t usagePage;
+    uint32_t usage;
+    int32_t value;
+    uint64_t timestamp;
+    std::string keyName;
+};
+
+// AsyncDataは削除（使用しない）
+
+class KeyboardDetector {
+public:
+    std::queue<KeyEvent> keyEventQueue;
+    std::mutex queueMutex;
+    napi_threadsafe_function keyEventCallback;
+
+private:
+    IOHIDManagerRef hidManager;
+    std::vector<KeyboardDevice> keyboards;
+    std::map<IOHIDDeviceRef, int> deviceToKeyboardMap;
+
+public:
+    KeyboardDetector() : keyEventCallback(nullptr), hidManager(nullptr) {}
+
+    ~KeyboardDetector() {
+        if (keyEventCallback) {
+            napi_release_threadsafe_function(keyEventCallback, napi_tsfn_release);
+        }
+        if (hidManager) {
+            IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
+            CFRelease(hidManager);
+        }
+    }
+
+    bool initialize() {
+        hidManager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+        if (!hidManager) {
+            std::cerr << "Failed to create IOHIDManager" << std::endl;
+            return false;
+        }
+
+        // Set up matching dictionary for keyboards
+        CFMutableDictionaryRef matchingDict = CFDictionaryCreateMutable(
+            kCFAllocatorDefault, 0,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+
+        if (!matchingDict) {
+            std::cerr << "Failed to create matching dictionary" << std::endl;
+            return false;
+        }
+
+        // Match HID keyboards (usage page 1, usage 6)
+        int usagePage = kHIDPage_GenericDesktop;
+        int usage = kHIDUsage_GD_Keyboard;
+
+        CFNumberRef usagePageRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usagePage);
+        CFNumberRef usageRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usage);
+
+        CFDictionarySetValue(matchingDict, CFSTR(kIOHIDDeviceUsagePageKey), usagePageRef);
+        CFDictionarySetValue(matchingDict, CFSTR(kIOHIDDeviceUsageKey), usageRef);
+
+        IOHIDManagerSetDeviceMatching(hidManager, matchingDict);
+
+        // Register callbacks
+        IOHIDManagerRegisterDeviceMatchingCallback(hidManager, deviceMatchingCallback, this);
+        IOHIDManagerRegisterDeviceRemovalCallback(hidManager, deviceRemovalCallback, this);
+
+        // Schedule with run loop
+        IOHIDManagerScheduleWithRunLoop(hidManager, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+
+        // Open the manager
+        IOReturn result = IOHIDManagerOpen(hidManager, kIOHIDOptionsTypeNone);
+        if (result != kIOReturnSuccess) {
+            std::cerr << "Failed to open IOHIDManager: " << result << std::endl;
+            CFRelease(matchingDict);
+            CFRelease(usagePageRef);
+            CFRelease(usageRef);
+            return false;
+        }
+
+        std::cout << "IOHIDManager initialized successfully" << std::endl;
+
+        // Clean up
+        CFRelease(matchingDict);
+        CFRelease(usagePageRef);
+        CFRelease(usageRef);
+
+        return true;
+    }
+
+    std::vector<KeyboardDevice> getDetectedKeyboards() {
+        return keyboards;
+    }
+
+    void scanForKeyboards() {
+        // Clear existing keyboards
+        keyboards.clear();
+        deviceToKeyboardMap.clear();
+
+        // Get current devices
+        CFSetRef devices = IOHIDManagerCopyDevices(hidManager);
+        if (!devices) {
+            std::cout << "No HID devices found" << std::endl;
+            return;
+        }
+
+        CFIndex deviceCount = CFSetGetCount(devices);
+        std::cout << "Found " << deviceCount << " HID devices" << std::endl;
+
+        if (deviceCount > 0) {
+            IOHIDDeviceRef* deviceArray = (IOHIDDeviceRef*)malloc(sizeof(IOHIDDeviceRef) * deviceCount);
+            CFSetGetValues(devices, (const void**)deviceArray);
+
+            for (CFIndex i = 0; i < deviceCount; i++) {
+                IOHIDDeviceRef device = deviceArray[i];
+                addKeyboard(device);
+            }
+
+            free(deviceArray);
+        }
+
+        CFRelease(devices);
+
+        std::cout << "Total keyboards detected: " << keyboards.size() << std::endl;
+    }
+
+    // キー入力イベントコールバック
+    static void inputValueCallback(void* context, IOReturn result, void* sender, IOHIDValueRef value) {
+        KeyboardDetector* detector = static_cast<KeyboardDetector*>(context);
+
+        IOHIDElementRef element = IOHIDValueGetElement(value);
+        IOHIDDeviceRef device = IOHIDElementGetDevice(element);
+
+        auto it = detector->deviceToKeyboardMap.find(device);
+        if (it == detector->deviceToKeyboardMap.end()) {
+            return; // デバイスが見つからない
+        }
+
+        int keyboardIndex = it->second;
+        if (keyboardIndex >= (int)detector->keyboards.size()) {
+            return;
+        }
+
+        uint32_t usagePage = IOHIDElementGetUsagePage(element);
+        uint32_t usage = IOHIDElementGetUsage(element);
+        CFIndex integerValue = IOHIDValueGetIntegerValue(value);
+        uint64_t timestamp = IOHIDValueGetTimeStamp(value);
+
+        // キーボードイベントのみ処理 (usage page 7 = キーボード/キーパッド)
+        if (usagePage == kHIDPage_KeyboardOrKeypad && integerValue > 0) { // キー押下時のみ
+            KeyEvent keyEvent;
+            keyEvent.keyboardId = detector->keyboards[keyboardIndex].keyboardId;
+            keyEvent.usagePage = usagePage;
+            keyEvent.usage = usage;
+            keyEvent.value = (int32_t)integerValue;
+            keyEvent.timestamp = timestamp;
+            keyEvent.keyName = detector->getKeyName(usage);
+
+            // キューに追加
+            {
+                std::lock_guard<std::mutex> lock(detector->queueMutex);
+                detector->keyEventQueue.push(keyEvent);
+            }
+
+            // JavaScriptコールバックがあれば呼び出し
+            if (detector->keyEventCallback) {
+                KeyEvent* eventCopy = new KeyEvent(keyEvent);
+                napi_call_threadsafe_function(detector->keyEventCallback, eventCopy, napi_tsfn_blocking);
+            }
+
+            std::cout << "🎹 Key from KB-" << keyEvent.keyboardId << ": "
+                      << keyEvent.keyName << " (usage: 0x" << std::hex << usage << std::dec << ")" << std::endl;
+        }
+    }
+
+    // HID usage codeからキー名に変換
+    std::string getKeyName(uint32_t usage) {
+        // 基本的なキーのマッピング
+        static const std::map<uint32_t, std::string> keyMap = {
+            {0x04, "a"}, {0x05, "b"}, {0x06, "c"}, {0x07, "d"}, {0x08, "e"}, {0x09, "f"},
+            {0x0A, "g"}, {0x0B, "h"}, {0x0C, "i"}, {0x0D, "j"}, {0x0E, "k"}, {0x0F, "l"},
+            {0x10, "m"}, {0x11, "n"}, {0x12, "o"}, {0x13, "p"}, {0x14, "q"}, {0x15, "r"},
+            {0x16, "s"}, {0x17, "t"}, {0x18, "u"}, {0x19, "v"}, {0x1A, "w"}, {0x1B, "x"},
+            {0x1C, "y"}, {0x1D, "z"},
+            {0x1E, "1"}, {0x1F, "2"}, {0x20, "3"}, {0x21, "4"}, {0x22, "5"},
+            {0x23, "6"}, {0x24, "7"}, {0x25, "8"}, {0x26, "9"}, {0x27, "0"},
+            {0x28, "Enter"}, {0x29, "Escape"}, {0x2A, "Backspace"}, {0x2B, "Tab"},
+            {0x2C, "Space"}, {0x2D, "-"}, {0x2E, "="}, {0x2F, "["}, {0x30, "]"},
+            {0x31, "\\"}, {0x33, ";"}, {0x34, "'"}, {0x35, "`"}, {0x36, ","},
+            {0x37, "."}, {0x38, "/"}, {0x39, "CapsLock"},
+            {0x3A, "F1"}, {0x3B, "F2"}, {0x3C, "F3"}, {0x3D, "F4"}, {0x3E, "F5"},
+            {0x3F, "F6"}, {0x40, "F7"}, {0x41, "F8"}, {0x42, "F9"}, {0x43, "F10"},
+            {0x44, "F11"}, {0x45, "F12"},
+            {0xE0, "LeftCtrl"}, {0xE1, "LeftShift"}, {0xE2, "LeftAlt"}, {0xE3, "LeftCmd"},
+            {0xE4, "RightCtrl"}, {0xE5, "RightShift"}, {0xE6, "RightAlt"}, {0xE7, "RightCmd"}
+        };
+
+        auto it = keyMap.find(usage);
+        if (it != keyMap.end()) {
+            return it->second;
+        }
+        return "Unknown(0x" + std::to_string(usage) + ")";
+    }
+
+private:
+    static void deviceMatchingCallback(void* context, IOReturn result, void* sender, IOHIDDeviceRef device) {
+        KeyboardDetector* detector = static_cast<KeyboardDetector*>(context);
+        std::cout << "Device connected" << std::endl;
+        detector->addKeyboard(device);
+    }
+
+    static void deviceRemovalCallback(void* context, IOReturn result, void* sender, IOHIDDeviceRef device) {
+        KeyboardDetector* detector = static_cast<KeyboardDetector*>(context);
+        std::cout << "Device disconnected" << std::endl;
+        detector->removeKeyboard(device);
+    }
+
+    void addKeyboard(IOHIDDeviceRef device) {
+        if (!device) return;
+
+        // Get device properties
+        CFStringRef productNameRef = (CFStringRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey));
+        CFStringRef manufacturerRef = (CFStringRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDManufacturerKey));
+        CFNumberRef vendorIdRef = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
+        CFNumberRef productIdRef = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey));
+        CFNumberRef locationIdRef = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDLocationIDKey));
+
+        KeyboardDevice kbd;
+
+        // Extract product name
+        if (productNameRef) {
+            const char* productName = CFStringGetCStringPtr(productNameRef, kCFStringEncodingUTF8);
+            if (productName) {
+                kbd.name = std::string(productName);
+            } else {
+                char buffer[256];
+                if (CFStringGetCString(productNameRef, buffer, sizeof(buffer), kCFStringEncodingUTF8)) {
+                    kbd.name = std::string(buffer);
+                }
+            }
+        } else {
+            kbd.name = "Unknown Keyboard";
+        }
+
+        // Extract manufacturer
+        if (manufacturerRef) {
+            const char* manufacturer = CFStringGetCStringPtr(manufacturerRef, kCFStringEncodingUTF8);
+            if (manufacturer) {
+                kbd.manufacturer = std::string(manufacturer);
+            } else {
+                char buffer[256];
+                if (CFStringGetCString(manufacturerRef, buffer, sizeof(buffer), kCFStringEncodingUTF8)) {
+                    kbd.manufacturer = std::string(buffer);
+                }
+            }
+        } else {
+            kbd.manufacturer = "Unknown";
+        }
+
+        // Extract vendor and product IDs
+        if (vendorIdRef) {
+            CFNumberGetValue(vendorIdRef, kCFNumberSInt32Type, &kbd.vendorId);
+        }
+
+        if (productIdRef) {
+            CFNumberGetValue(productIdRef, kCFNumberSInt32Type, &kbd.productId);
+        }
+
+        if (locationIdRef) {
+            CFNumberGetValue(locationIdRef, kCFNumberSInt32Type, &kbd.locationId);
+        }
+
+        kbd.device = device;
+
+        // キーボードをリストに追加してからIDを設定
+        keyboards.push_back(kbd);
+        int keyboardIndex = keyboards.size() - 1;
+
+        // キーボードIDは1ベースで設定（kb-1, kb-2, ...）
+        keyboards[keyboardIndex].keyboardId = keyboardIndex + 1;
+
+        // 入力値コールバックを登録
+        IOHIDDeviceRegisterInputValueCallback(device, inputValueCallback, this);
+
+        deviceToKeyboardMap[device] = keyboardIndex;
+
+        std::cout << "Added keyboard: " << kbd.name << " (" << kbd.manufacturer << ")" << std::endl;
+        std::cout << "  Vendor ID: 0x" << std::hex << kbd.vendorId << std::dec << std::endl;
+        std::cout << "  Product ID: 0x" << std::hex << kbd.productId << std::dec << std::endl;
+        std::cout << "  Location ID: 0x" << std::hex << kbd.locationId << std::dec << std::endl;
+    }
+
+    void removeKeyboard(IOHIDDeviceRef device) {
+        auto it = deviceToKeyboardMap.find(device);
+        if (it != deviceToKeyboardMap.end()) {
+            int index = it->second;
+            if (index >= 0 && index < (int)keyboards.size()) {
+                std::cout << "Removed keyboard: " << keyboards[index].name << std::endl;
+                keyboards.erase(keyboards.begin() + index);
+                deviceToKeyboardMap.erase(it);
+
+                // Update remaining indices
+                for (auto& pair : deviceToKeyboardMap) {
+                    if (pair.second > index) {
+                        pair.second--;
+                    }
+                }
+            }
+        }
+    }
+};
+
+static KeyboardDetector* detector = nullptr;
+
+napi_value Initialize(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        detector = new KeyboardDetector();
+    }
+
+    bool success = detector->initialize();
+
+    napi_value result;
+    napi_get_boolean(env, success, &result);
+    return result;
+}
+
+napi_value ScanKeyboards(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        napi_value result;
+        napi_create_array_with_length(env, 0, &result);
+        return result;
+    }
+
+    detector->scanForKeyboards();
+    std::vector<KeyboardDevice> keyboards = detector->getDetectedKeyboards();
+
+    napi_value result;
+    napi_create_array_with_length(env, keyboards.size(), &result);
+
+    for (size_t i = 0; i < keyboards.size(); i++) {
+        napi_value keyboard;
+        napi_create_object(env, &keyboard);
+
+        napi_value name, manufacturer, vendorId, productId, locationId;
+        napi_create_string_utf8(env, keyboards[i].name.c_str(), NAPI_AUTO_LENGTH, &name);
+        napi_create_string_utf8(env, keyboards[i].manufacturer.c_str(), NAPI_AUTO_LENGTH, &manufacturer);
+        napi_create_uint32(env, keyboards[i].vendorId, &vendorId);
+        napi_create_uint32(env, keyboards[i].productId, &productId);
+        napi_create_uint32(env, keyboards[i].locationId, &locationId);
+
+        napi_set_named_property(env, keyboard, "name", name);
+        napi_set_named_property(env, keyboard, "manufacturer", manufacturer);
+        napi_set_named_property(env, keyboard, "vendorId", vendorId);
+        napi_set_named_property(env, keyboard, "productId", productId);
+        napi_set_named_property(env, keyboard, "locationId", locationId);
+
+        napi_set_element(env, result, i, keyboard);
+    }
+
+    return result;
+}
+
+napi_value GetKeyboardCount(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        napi_value result;
+        napi_create_uint32(env, 0, &result);
+        return result;
+    }
+
+    std::vector<KeyboardDevice> keyboards = detector->getDetectedKeyboards();
+
+    napi_value result;
+    napi_create_uint32(env, keyboards.size(), &result);
+    return result;
+}
+
+// キーイベントコールバック用のスレッドセーフ関数コールバック
+void keyEventCallbackJS(napi_env env, napi_value js_callback, void* context, void* data) {
+    KeyEvent* keyEvent = static_cast<KeyEvent*>(data);
+
+    if (env != nullptr) {
+        napi_value undefined, keyEventObj;
+        napi_get_undefined(env, &undefined);
+
+        // KeyEventオブジェクトを作成
+        napi_create_object(env, &keyEventObj);
+
+        napi_value keyboardId, usagePage, usage, value, timestamp, keyName;
+        napi_create_int32(env, keyEvent->keyboardId, &keyboardId);
+        napi_create_uint32(env, keyEvent->usagePage, &usagePage);
+        napi_create_uint32(env, keyEvent->usage, &usage);
+        napi_create_int32(env, keyEvent->value, &value);
+        napi_create_bigint_uint64(env, keyEvent->timestamp, &timestamp);
+        napi_create_string_utf8(env, keyEvent->keyName.c_str(), NAPI_AUTO_LENGTH, &keyName);
+
+        napi_set_named_property(env, keyEventObj, "keyboardId", keyboardId);
+        napi_set_named_property(env, keyEventObj, "usagePage", usagePage);
+        napi_set_named_property(env, keyEventObj, "usage", usage);
+        napi_set_named_property(env, keyEventObj, "value", value);
+        napi_set_named_property(env, keyEventObj, "timestamp", timestamp);
+        napi_set_named_property(env, keyEventObj, "keyName", keyName);
+
+        // コールバックを呼び出し
+        if (js_callback != nullptr) {
+            napi_value global, result;
+            napi_get_global(env, &global);
+            napi_call_function(env, global, js_callback, 1, &keyEventObj, &result);
+        }
+    }
+
+    delete keyEvent;
+}
+
+napi_value SetKeyEventCallback(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    if (argc != 1) {
+        napi_throw_error(env, nullptr, "Expected exactly one argument (callback function)");
+        return nullptr;
+    }
+
+    napi_valuetype valuetype;
+    napi_typeof(env, args[0], &valuetype);
+    if (valuetype != napi_function) {
+        napi_throw_error(env, nullptr, "Expected first argument to be a function");
+        return nullptr;
+    }
+
+    if (!detector) {
+        napi_throw_error(env, nullptr, "Detector not initialized");
+        return nullptr;
+    }
+
+    // 既存のコールバックをクリーンアップ
+    if (detector->keyEventCallback) {
+        napi_release_threadsafe_function(detector->keyEventCallback, napi_tsfn_release);
+    }
+
+    // スレッドセーフ関数を作成
+    napi_value resourceName;
+    napi_create_string_utf8(env, "KeyEventCallback", NAPI_AUTO_LENGTH, &resourceName);
+
+    napi_create_threadsafe_function(
+        env,
+        args[0],
+        nullptr,
+        resourceName,
+        0,
+        1,
+        nullptr,
+        nullptr,
+        nullptr,
+        keyEventCallbackJS,
+        &detector->keyEventCallback
+    );
+
+    napi_value result;
+    napi_get_boolean(env, true, &result);
+    return result;
+}
+
+napi_value GetNextKeyEvent(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        napi_value result;
+        napi_get_null(env, &result);
+        return result;
+    }
+
+    std::lock_guard<std::mutex> lock(detector->queueMutex);
+    if (detector->keyEventQueue.empty()) {
+        napi_value result;
+        napi_get_null(env, &result);
+        return result;
+    }
+
+    KeyEvent keyEvent = detector->keyEventQueue.front();
+    detector->keyEventQueue.pop();
+
+    // KeyEventオブジェクトを作成
+    napi_value keyEventObj;
+    napi_create_object(env, &keyEventObj);
+
+    napi_value keyboardId, usagePage, usage, value, timestamp, keyName;
+    napi_create_int32(env, keyEvent.keyboardId, &keyboardId);
+    napi_create_uint32(env, keyEvent.usagePage, &usagePage);
+    napi_create_uint32(env, keyEvent.usage, &usage);
+    napi_create_int32(env, keyEvent.value, &value);
+    napi_create_bigint_uint64(env, keyEvent.timestamp, &timestamp);
+    napi_create_string_utf8(env, keyEvent.keyName.c_str(), NAPI_AUTO_LENGTH, &keyName);
+
+    napi_set_named_property(env, keyEventObj, "keyboardId", keyboardId);
+    napi_set_named_property(env, keyEventObj, "usagePage", usagePage);
+    napi_set_named_property(env, keyEventObj, "usage", usage);
+    napi_set_named_property(env, keyEventObj, "value", value);
+    napi_set_named_property(env, keyEventObj, "timestamp", timestamp);
+    napi_set_named_property(env, keyEventObj, "keyName", keyName);
+
+    return keyEventObj;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+    napi_value initializeFn, scanKeyboardsFn, getKeyboardCountFn, setKeyEventCallbackFn, getNextKeyEventFn;
+
+    napi_create_function(env, nullptr, 0, Initialize, nullptr, &initializeFn);
+    napi_create_function(env, nullptr, 0, ScanKeyboards, nullptr, &scanKeyboardsFn);
+    napi_create_function(env, nullptr, 0, GetKeyboardCount, nullptr, &getKeyboardCountFn);
+    napi_create_function(env, nullptr, 0, SetKeyEventCallback, nullptr, &setKeyEventCallbackFn);
+    napi_create_function(env, nullptr, 0, GetNextKeyEvent, nullptr, &getNextKeyEventFn);
+
+    napi_set_named_property(env, exports, "initialize", initializeFn);
+    napi_set_named_property(env, exports, "scanKeyboards", scanKeyboardsFn);
+    napi_set_named_property(env, exports, "getKeyboardCount", getKeyboardCountFn);
+    napi_set_named_property(env, exports, "setKeyEventCallback", setKeyEventCallbackFn);
+    napi_set_named_property(env, exports, "getNextKeyEvent", getNextKeyEventFn);
+
+    return exports;
+}
+
+NAPI_MODULE(keyboard_detector, Init)

--- a/native-keyboard-addon/src/keyboard_detector_mac.mm
+++ b/native-keyboard-addon/src/keyboard_detector_mac.mm
@@ -122,9 +122,8 @@ public:
     }
 
     void scanForKeyboards() {
-        // Clear existing keyboards
-        keyboards.clear();
-        deviceToKeyboardMap.clear();
+        // 既存のキーボードはクリアしない（重複を防ぐため）
+        std::cout << "Scanning for keyboards (current count: " << keyboards.size() << ")..." << std::endl;
 
         // Get current devices
         CFSetRef devices = IOHIDManagerCopyDevices(hidManager);
@@ -142,7 +141,14 @@ public:
 
             for (CFIndex i = 0; i < deviceCount; i++) {
                 IOHIDDeviceRef device = deviceArray[i];
-                addKeyboard(device);
+
+                // 既に追加済みかチェック
+                auto it = deviceToKeyboardMap.find(device);
+                if (it == deviceToKeyboardMap.end()) {
+                    addKeyboard(device);
+                } else {
+                    std::cout << "Device already scanned, skipping..." << std::endl;
+                }
             }
 
             free(deviceArray);
@@ -235,6 +241,14 @@ private:
     static void deviceMatchingCallback(void* context, IOReturn result, void* sender, IOHIDDeviceRef device) {
         KeyboardDetector* detector = static_cast<KeyboardDetector*>(context);
         std::cout << "Device connected" << std::endl;
+
+        // 既に追加済みかチェック
+        auto it = detector->deviceToKeyboardMap.find(device);
+        if (it != detector->deviceToKeyboardMap.end()) {
+            std::cout << "Device already exists, skipping..." << std::endl;
+            return;
+        }
+
         detector->addKeyboard(device);
     }
 

--- a/native-keyboard-addon/test-real-input.js
+++ b/native-keyboard-addon/test-real-input.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const { KeyboardDetector } = require('./index.js');
+
+console.log('=== リアル入力キャプチャテスト ===');
+
+async function runKeyInputTest() {
+    const detector = new KeyboardDetector();
+
+    console.log('\n1. 初期化中...');
+    const initialized = detector.initialize();
+
+    if (!initialized) {
+        console.error('❌ 初期化失敗');
+        process.exit(1);
+    }
+
+    console.log('\n2. キーボード検知中...');
+    const keyboards = detector.scanKeyboards();
+
+    if (keyboards.length === 0) {
+        console.error('❌ キーボードが検知できませんでした');
+        process.exit(1);
+    }
+
+    console.log(`\n✅ ${keyboards.length}個のキーボードを検知:`);
+    keyboards.forEach((kb, i) => {
+        console.log(`  KB-${i + 1}: ${kb.name} (${kb.manufacturer})`);
+    });
+
+    console.log('\n3. 個別キー入力監視開始...');
+    console.log('💡 各キーボードで文字を入力してください (10秒間)');
+    console.log('💡 Ctrl+C で終了');
+
+    // コールバック方式
+    detector.setKeyEventCallback((keyEvent) => {
+        console.log(`🎹 KB-${keyEvent.keyboardId}: "${keyEvent.keyName}" (usage: 0x${keyEvent.usage.toString(16)})`);
+    });
+
+    // テスト期間
+    setTimeout(() => {
+        console.log('\n4. 10秒経過しました。手動テストが続行できます。');
+    }, 10000);
+
+    // SIGINT (Ctrl+C) ハンドラ
+    process.on('SIGINT', () => {
+        console.log('\n\n=== テスト終了 ===');
+        console.log('✅ 個別キーボード入力キャプチャが動作しました！');
+        process.exit(0);
+    });
+}
+
+// エラーハンドリング
+process.on('uncaughtException', (error) => {
+    console.error('\n❌ エラー:', error.message);
+    process.exit(1);
+});
+
+runKeyInputTest().catch((error) => {
+    console.error('\n❌ テスト失敗:', error.message);
+    process.exit(1);
+});

--- a/native-keyboard-addon/test.js
+++ b/native-keyboard-addon/test.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const { KeyboardDetector } = require('./index.js');
+
+console.log('=== Native Keyboard Detection Test ===');
+
+async function runTest() {
+    const detector = new KeyboardDetector();
+
+    console.log('\n1. Testing initialization...');
+    const initialized = detector.initialize();
+
+    if (!initialized) {
+        console.error('❌ Failed to initialize keyboard detector');
+        console.error('This might be due to:');
+        console.error('  1. Missing permissions (Input Monitoring)');
+        console.error('  2. macOS security restrictions');
+        console.error('  3. Native addon build issues');
+        process.exit(1);
+    }
+
+    console.log('✅ Keyboard detector initialized successfully');
+
+    console.log('\n2. Testing keyboard scan...');
+    const keyboards = detector.scanKeyboards();
+
+    console.log(`\n3. Results:`);
+    console.log(`   Found ${keyboards.length} keyboard(s)`);
+
+    if (keyboards.length === 0) {
+        console.log('\n⚠️ No keyboards detected. This could be due to:');
+        console.log('   1. macOS security restrictions (Input Monitoring permission)');
+        console.log('   2. Missing entitlements in the application');
+        console.log('   3. IOHIDManager configuration issues');
+
+        console.log('\n🔧 Debugging steps:');
+        console.log('   1. Check System Preferences > Security & Privacy > Input Monitoring');
+        console.log('   2. Ensure Terminal or your app has permission');
+        console.log('   3. Try running with sudo (for testing only)');
+        console.log('   4. Connect an external USB keyboard for testing');
+    } else {
+        console.log('\n✅ Keyboards detected successfully:');
+        keyboards.forEach((kbd, index) => {
+            console.log(`\nKeyboard ${index + 1}:`);
+            console.log(`  📱 Name: ${kbd.name}`);
+            console.log(`  🏭 Manufacturer: ${kbd.manufacturer}`);
+            console.log(`  🔢 Vendor ID: 0x${kbd.vendorId.toString(16).toUpperCase()}`);
+            console.log(`  🆔 Product ID: 0x${kbd.productId.toString(16).toUpperCase()}`);
+            console.log(`  📍 Location ID: 0x${kbd.locationId.toString(16).toUpperCase()}`);
+        });
+    }
+
+    console.log('\n4. Testing keyboard count...');
+    const count = detector.getKeyboardCount();
+    console.log(`   Count verification: ${count}`);
+
+    console.log('\n=== Test Complete ===');
+
+    if (keyboards.length > 0) {
+        console.log('🎉 Success! Multiple keyboard detection is working.');
+    } else {
+        console.log('⚠️ No keyboards detected. Check permissions and setup.');
+    }
+}
+
+// Handle errors gracefully
+process.on('uncaughtException', (error) => {
+    console.error('\n❌ Uncaught Exception:', error.message);
+    console.error('Stack trace:', error.stack);
+    process.exit(1);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+    console.error('\n❌ Unhandled Rejection at:', promise, 'reason:', reason);
+    process.exit(1);
+});
+
+// Run the test
+runTest().catch((error) => {
+    console.error('\n❌ Test failed:', error.message);
+    console.error(error.stack);
+    process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "node-hid": "^2.1.2"
+        "node-gyp": "^11.4.2",
+        "node-hid": "^2.2.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.5",
@@ -1453,7 +1454,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1471,7 +1471,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1484,7 +1483,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1497,14 +1495,12 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1522,7 +1518,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -1538,7 +1533,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1550,6 +1544,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2380,6 +2395,71 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@npmcli/agent/node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
@@ -2413,7 +2493,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3186,7 +3265,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3196,7 +3274,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3556,7 +3633,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -3612,7 +3688,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4196,7 +4271,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4209,7 +4283,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/combined-stream": {
@@ -4492,7 +4565,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4552,7 +4624,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4967,7 +5038,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -5216,14 +5286,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/encoding": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5256,7 +5324,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5266,7 +5333,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/error-ex": {
@@ -5624,7 +5690,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
       "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/extract-zip": {
@@ -5859,7 +5924,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -5876,7 +5940,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6235,7 +6298,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -6383,7 +6445,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-proxy-agent": {
@@ -6471,7 +6532,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6551,7 +6612,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -6602,7 +6662,6 @@
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
       "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6658,7 +6717,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6781,7 +6839,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -6872,7 +6929,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -8186,7 +8242,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/make-dir": {
@@ -8400,7 +8455,6 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -8444,7 +8498,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -8457,7 +8510,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -8470,7 +8522,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -8516,7 +8567,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-build-utils": {
@@ -8577,6 +8627,332 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.4.2.tgz",
+      "integrity": "sha512-3gD+6zsrLQH7DyYOUIutaauuXrcyxeTPyQuZQCQoNPZMHMMS5m4y0xclNpvYzoK3VNzuyxT6eF4mkIL4WSZ1eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.4.3",
+        "tinyglobby": "^0.2.12",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/@npmcli/fs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+      "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/cacache": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^4.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/node-gyp/node_modules/make-fetch-happen": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^4.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^12.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minipass-fetch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+      "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/node-gyp/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp/node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/node-gyp/node_modules/proc-log": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/ssri": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/tar": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.4.tgz",
+      "integrity": "sha512-O1z7ajPkjTgEgmTGz0v9X4eqeEXTDREPTO77pVC1Nbs86feBU1Zhdg+edzavPmYW1olxkwsqA2v4uOw6E8LeDg==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/node-gyp/node_modules/unique-filename": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+      "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/unique-slug": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+      "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/node-hid": {
@@ -8857,7 +9233,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/parent-module": {
@@ -8929,7 +9304,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8946,7 +9320,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -8963,7 +9336,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -9247,7 +9619,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
@@ -9564,7 +9935,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -9682,7 +10052,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
@@ -9770,7 +10140,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9783,7 +10152,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9904,7 +10272,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
@@ -9915,7 +10282,6 @@
       "version": "2.8.7",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
       "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.0.1",
@@ -10049,7 +10415,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10065,7 +10430,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10080,7 +10444,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10094,7 +10457,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10455,6 +10817,51 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tldts": {
@@ -11054,7 +11461,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11106,7 +11512,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -11213,7 +11618,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "dist:mac": "electron-builder --mac"
   },
   "dependencies": {
-    "node-hid": "^2.1.2",
-    "node-gyp": "^11.4.2"
+    "node-gyp": "^11.4.2",
+    "node-hid": "^2.2.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Multi-keyboard typing game for kindergarten children",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "npm run build && electron .",
     "dev": "electron . --dev",
     "build": "tsc && npm run copy-assets",
     "copy-assets": "cp src/presentation/index.html dist/presentation/ && cp src/presentation/simple-renderer.js dist/presentation/ && cp -r src/presentation/styles dist/presentation/",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "keyboard-game",
   "version": "1.0.0",
   "description": "Multi-keyboard typing game for kindergarten children",
-  "main": "dist/main.js",
+  "main": "main.js",
   "scripts": {
-    "build": "tsc && npm run copy-assets",
     "start": "electron .",
-    "dev": "npm run build && npm start",
+    "dev": "electron . --dev",
+    "build": "tsc && npm run copy-assets",
     "copy-assets": "cp src/presentation/index.html dist/presentation/ && cp src/presentation/simple-renderer.js dist/presentation/ && cp -r src/presentation/styles dist/presentation/",
     "test": "jest",
     "test:watch": "jest --watch",
@@ -18,7 +18,8 @@
     "dist:mac": "electron-builder --mac"
   },
   "dependencies": {
-    "node-hid": "^2.1.2"
+    "node-hid": "^2.1.2",
+    "node-gyp": "^11.4.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.5",

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,34 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+// セキュアなAPIをレンダラープロセスに公開
+contextBridge.exposeInMainWorld('electronAPI', {
+    // キーボード関連API
+    getKeyboards: () => ipcRenderer.invoke('get-keyboards'),
+    rescanKeyboards: () => ipcRenderer.invoke('rescan-keyboards'),
+
+    // 入力履歴API
+    getInputHistory: () => ipcRenderer.invoke('get-input-history'),
+    clearHistory: () => ipcRenderer.invoke('clear-history'),
+
+    // イベントリスナー
+    onKeyboardsDetected: (callback) => {
+        ipcRenderer.on('keyboards-detected', (event, keyboards) => callback(keyboards));
+    },
+
+    onKeyboardsUpdated: (callback) => {
+        ipcRenderer.on('keyboards-updated', (event, keyboards) => callback(keyboards));
+    },
+
+    onRealKeyInput: (callback) => {
+        ipcRenderer.on('real-key-input', (event, keyEvent) => callback(keyEvent));
+    },
+
+    onKeyInput: (callback) => {
+        ipcRenderer.on('key-input', (event, keyEvent) => callback(keyEvent));
+    },
+
+    // クリーンアップ
+    removeAllListeners: (channel) => {
+        ipcRenderer.removeAllListeners(channel);
+    }
+});

--- a/renderer.js
+++ b/renderer.js
@@ -1356,11 +1356,25 @@ class KeyboardConnectionManager {
     }
 
     showTargetCountSection() {
-        const container = document.querySelector('.setup-panel');
+        // 複数の候補でコンテナを探す
+        let container = document.querySelector('.setup-panel');
+
         if (!container) {
-            console.error('Setup container not found - .setup-panel');
+            // setup-panelが見つからない場合は、最後に追加されたセクションの親を探す
+            container = document.getElementById('keyboard-assignment-section')?.parentNode;
+        }
+
+        if (!container) {
+            // それでも見つからない場合は、game-containerを使用
+            container = document.querySelector('.game-container');
+        }
+
+        if (!container) {
+            console.error('Setup container not found - tried .setup-panel, keyboard-assignment parent, .game-container');
             return;
         }
+
+        console.log('Container found:', container.className || container.id);
 
         // 既存のお題数設定セクションを削除
         const existingSection = document.getElementById('target-count-section');
@@ -1499,11 +1513,26 @@ class KeyboardConnectionManager {
     }
 
     showGameStartSection() {
-        const container = document.querySelector('.setup-panel');
+        // 複数の候補でコンテナを探す
+        let container = document.querySelector('.setup-panel');
+
         if (!container) {
-            console.error('Setup container not found for game start section');
+            // setup-panelが見つからない場合は、最後に追加されたセクションの親を探す
+            container = document.getElementById('target-count-section')?.parentNode ||
+                       document.getElementById('keyboard-assignment-section')?.parentNode;
+        }
+
+        if (!container) {
+            // それでも見つからない場合は、game-containerを使用
+            container = document.querySelector('.game-container');
+        }
+
+        if (!container) {
+            console.error('Game start container not found - tried multiple selectors');
             return;
         }
+
+        console.log('Game start container found:', container.className || container.id);
 
         // 既存のゲーム開始セクションを削除
         const existingSection = document.getElementById('game-start-section');

--- a/renderer.js
+++ b/renderer.js
@@ -1,0 +1,351 @@
+// レンダラープロセス - 1.1 キーボード接続確認UI
+
+class KeyboardConnectionManager {
+    constructor() {
+        this.keyboards = [];
+        this.isMonitoring = true;
+        this.activityBuffer = [];
+        this.keyboardActivities = new Map();
+        this.lastScanTime = Date.now();
+
+        this.init();
+    }
+
+    async init() {
+        console.log('=== Keyboard Connection Manager 初期化 ===');
+
+        this.setupEventListeners();
+        this.setupUIHandlers();
+
+        // 初期キーボード情報取得
+        try {
+            const keyboards = await window.electronAPI.getKeyboards();
+            this.updateKeyboards(keyboards);
+        } catch (error) {
+            console.error('初期キーボード取得エラー:', error);
+        }
+
+        this.updateStatus('キーボード検知完了 - タイピングテストを開始できます');
+    }
+
+    setupEventListeners() {
+        // キーボード検知イベント
+        window.electronAPI.onKeyboardsDetected((keyboards) => {
+            console.log('キーボード検知:', keyboards);
+            this.updateKeyboards(keyboards);
+        });
+
+        // キーボード更新イベント
+        window.electronAPI.onKeyboardsUpdated((keyboards) => {
+            console.log('キーボード更新:', keyboards);
+            this.updateKeyboards(keyboards);
+            this.showConnectionChange(keyboards);
+        });
+
+        // リアルタイム入力イベント
+        window.electronAPI.onRealKeyInput((keyEvent) => {
+            if (this.isMonitoring) {
+                this.handleRealKeyInput(keyEvent);
+            }
+        });
+
+        // フォールバック入力イベント
+        window.electronAPI.onKeyInput((keyEvent) => {
+            if (this.isMonitoring) {
+                this.handleKeyInput(keyEvent);
+            }
+        });
+    }
+
+    setupUIHandlers() {
+        // グローバル関数として定義（HTMLから呼び出し可能）
+        window.rescanKeyboards = () => this.rescanKeyboards();
+        window.testAllKeyboards = () => this.testAllKeyboards();
+        window.clearActivityLog = () => this.clearActivityLog();
+        window.toggleMonitoring = () => this.toggleMonitoring();
+        window.exportLog = () => this.exportLog();
+        window.proceedToNextStep = () => this.proceedToNextStep();
+    }
+
+    updateKeyboards(keyboards) {
+        // LocationIDベースで重複除去（念のため）
+        const uniqueKeyboards = [];
+        const seenLocationIds = new Set();
+
+        for (const keyboard of keyboards) {
+            if (!seenLocationIds.has(keyboard.locationId)) {
+                seenLocationIds.add(keyboard.locationId);
+                uniqueKeyboards.push(keyboard);
+            }
+        }
+
+        this.keyboards = uniqueKeyboards;
+        console.log(`UI更新: ${this.keyboards.length}台のキーボード`);
+
+        this.renderKeyboards();
+        this.updateKeyboardCount();
+        this.checkNextStepAvailability();
+    }
+
+    renderKeyboards() {
+        const container = document.getElementById('keyboards-grid');
+        if (!container) return;
+
+        if (this.keyboards.length === 0) {
+            container.innerHTML = `
+                <div style="grid-column: 1 / -1; text-align: center; padding: 40px; color: #718096;">
+                    <div style="font-size: 3em; margin-bottom: 20px;">🔍</div>
+                    <div style="font-size: 1.2em; margin-bottom: 10px;">キーボードが見つかりません</div>
+                    <div>キーボードを接続して「再スキャン」ボタンを押してください</div>
+                </div>
+            `;
+            return;
+        }
+
+        container.innerHTML = this.keyboards.map(keyboard => {
+            const activity = this.keyboardActivities.get(keyboard.id) || [];
+            const recentActivity = activity.slice(-5).reverse();
+
+            return `
+                <div class="keyboard-card ${keyboard.connected ? 'connected' : 'disconnected'}" data-keyboard-id="${keyboard.id}">
+                    <div class="keyboard-status ${keyboard.connected ? 'connected' : 'disconnected'}">
+                        ${keyboard.connected ? '✅ 接続中' : '❌ 切断'}
+                    </div>
+                    <div class="keyboard-name">${this.escapeHtml(keyboard.name)}</div>
+                    <div class="keyboard-info">
+                        <div>メーカー: ${this.escapeHtml(keyboard.manufacturer)}</div>
+                        <div>ID: ${keyboard.id}</div>
+                        <div>VID: 0x${keyboard.vendorId.toString(16).padStart(4, '0').toUpperCase()}</div>
+                        <div>PID: 0x${keyboard.productId.toString(16).padStart(4, '0').toUpperCase()}</div>
+                    </div>
+                    <div class="keyboard-activity" id="activity-${keyboard.id}">
+                        ${recentActivity.length > 0
+                            ? recentActivity.map(entry =>
+                                `<div style="margin-bottom: 2px;">
+                                    <span class="timestamp">${entry.time}</span>
+                                    <span class="key-display">${entry.key}</span>
+                                </div>`
+                              ).join('')
+                            : '<div style="color: #a0aec0; font-style: italic;">タイピングして動作確認...</div>'
+                        }
+                    </div>
+                </div>
+            `;
+        }).join('');
+    }
+
+    updateKeyboardCount() {
+        const countElement = document.getElementById('keyboard-count');
+        if (countElement) {
+            const connectedCount = this.keyboards.filter(kb => kb.connected).length;
+            countElement.textContent = `${connectedCount}台`;
+
+            if (connectedCount === 0) {
+                countElement.style.background = '#f56565';
+            } else if (connectedCount >= 2) {
+                countElement.style.background = '#48bb78';
+            } else {
+                countElement.style.background = '#ed8936';
+            }
+        }
+    }
+
+    handleRealKeyInput(keyEvent) {
+        const timestamp = new Date().toLocaleTimeString();
+        const logEntry = `[${timestamp}] 🎹 ${keyEvent.keyboardId}: ${keyEvent.key}`;
+
+        this.addToActivityLog(logEntry, 'native');
+        this.updateKeyboardActivity(keyEvent.keyboardId, keyEvent.key, timestamp);
+    }
+
+    handleKeyInput(keyEvent) {
+        const timestamp = new Date().toLocaleTimeString();
+        const logEntry = `[${timestamp}] ⌨️  ${keyEvent.keyboardId}: ${keyEvent.key}`;
+
+        this.addToActivityLog(logEntry, 'electron');
+        this.updateKeyboardActivity(keyEvent.keyboardId, keyEvent.key, timestamp);
+    }
+
+    updateKeyboardActivity(keyboardId, key, timestamp) {
+        if (!this.keyboardActivities.has(keyboardId)) {
+            this.keyboardActivities.set(keyboardId, []);
+        }
+
+        const activity = this.keyboardActivities.get(keyboardId);
+        activity.push({ key, time: timestamp });
+
+        // 最新10件のみ保持
+        if (activity.length > 10) {
+            activity.shift();
+        }
+
+        // 該当キーボードカードの活動表示を更新
+        const activityElement = document.getElementById(`activity-${keyboardId}`);
+        if (activityElement) {
+            const recentActivity = activity.slice(-5).reverse();
+            activityElement.innerHTML = recentActivity.map(entry =>
+                `<div style="margin-bottom: 2px;">
+                    <span class="timestamp">${entry.time}</span>
+                    <span class="key-display">${entry.key}</span>
+                </div>`
+            ).join('');
+
+            // キーボードカードをハイライト
+            const card = activityElement.closest('.keyboard-card');
+            if (card) {
+                card.style.transform = 'scale(1.02)';
+                card.style.boxShadow = '0 8px 25px rgba(66, 153, 225, 0.3)';
+                setTimeout(() => {
+                    card.style.transform = '';
+                    card.style.boxShadow = '';
+                }, 200);
+            }
+        }
+    }
+
+    addToActivityLog(message, type = 'info') {
+        this.activityBuffer.push({ message, type, timestamp: Date.now() });
+
+        // バッファサイズ制限
+        if (this.activityBuffer.length > 200) {
+            this.activityBuffer.shift();
+        }
+
+        const logElement = document.getElementById('activity-log');
+        if (logElement) {
+            logElement.textContent += message + '\n';
+            logElement.scrollTop = logElement.scrollHeight;
+        }
+    }
+
+    showConnectionChange(keyboards) {
+        const connectedCount = keyboards.filter(kb => kb.connected).length;
+        const message = `キーボード接続状態が変更されました（${connectedCount}台接続中）`;
+
+        this.updateStatus(message);
+        this.addToActivityLog(`[システム] ${message}`, 'system');
+    }
+
+    updateStatus(message) {
+        const statusElement = document.getElementById('status');
+        if (statusElement) {
+            statusElement.textContent = message;
+        }
+    }
+
+    checkNextStepAvailability() {
+        const nextStepBtn = document.getElementById('nextStepBtn');
+        if (nextStepBtn) {
+            const connectedCount = this.keyboards.filter(kb => kb.connected).length;
+
+            if (connectedCount >= 2) {
+                nextStepBtn.disabled = false;
+                nextStepBtn.style.background = '#48bb78';
+                nextStepBtn.textContent = `1.2 プレイヤー集合へ進む（${connectedCount}台のキーボード確認済み）`;
+            } else {
+                nextStepBtn.disabled = true;
+                nextStepBtn.style.background = '#a0aec0';
+                nextStepBtn.textContent = connectedCount === 0
+                    ? 'キーボードを接続してください'
+                    : `もう1台以上キーボードが必要です（現在${connectedCount}台）`;
+            }
+        }
+    }
+
+    // UI イベントハンドラー
+    async rescanKeyboards() {
+        this.updateStatus('キーボードを再スキャン中...');
+
+        try {
+            const keyboards = await window.electronAPI.rescanKeyboards();
+            this.updateKeyboards(keyboards);
+            this.addToActivityLog('[システム] キーボード再スキャン完了', 'system');
+            this.updateStatus('再スキャン完了');
+        } catch (error) {
+            console.error('再スキャンエラー:', error);
+            this.updateStatus('再スキャンに失敗しました');
+        }
+    }
+
+    testAllKeyboards() {
+        this.addToActivityLog('[システム] 全キーボードテスト開始 - 各キーボードで何かキーを押してください', 'system');
+        this.updateStatus('全キーボードテスト中 - 各キーボードでタイピングしてください');
+
+        // 30秒後にテスト終了
+        setTimeout(() => {
+            this.addToActivityLog('[システム] キーボードテスト終了', 'system');
+            this.updateStatus('キーボードテスト完了');
+        }, 30000);
+    }
+
+    clearActivityLog() {
+        const logElement = document.getElementById('activity-log');
+        if (logElement) {
+            logElement.textContent = '=== キーボード入力監視開始 ===\nキーボードでタイピングしてテストしてください...\n\n';
+        }
+
+        this.activityBuffer = [];
+        this.keyboardActivities.clear();
+        this.renderKeyboards(); // アクティビティ表示をクリア
+
+        window.electronAPI.clearHistory();
+        this.addToActivityLog('[システム] ログをクリアしました', 'system');
+    }
+
+    toggleMonitoring() {
+        this.isMonitoring = !this.isMonitoring;
+        const btn = document.getElementById('monitorBtn');
+
+        if (this.isMonitoring) {
+            btn.textContent = '⏸️ 監視停止';
+            this.addToActivityLog('[システム] 入力監視を再開しました', 'system');
+            this.updateStatus('入力監視中');
+        } else {
+            btn.textContent = '▶️ 監視開始';
+            this.addToActivityLog('[システム] 入力監視を停止しました', 'system');
+            this.updateStatus('入力監視停止中');
+        }
+    }
+
+    exportLog() {
+        const logData = {
+            timestamp: new Date().toISOString(),
+            keyboards: this.keyboards,
+            activities: Object.fromEntries(this.keyboardActivities),
+            activityBuffer: this.activityBuffer
+        };
+
+        const blob = new Blob([JSON.stringify(logData, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `keyboard-test-log-${Date.now()}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+
+        this.addToActivityLog('[システム] ログファイルを保存しました', 'system');
+    }
+
+    proceedToNextStep() {
+        this.addToActivityLog('[システム] 次のステップに進みます...', 'system');
+        this.updateStatus('1.2 プレイヤー集合の準備中...');
+
+        // TODO: 次のステップの実装
+        alert('次のステップ「1.2 プレイヤー集合」の実装はまだ準備中です。\n現在は1.1のキーボード接続確認が完了しました！');
+    }
+
+    escapeHtml(text) {
+        const div = document.createElement('div');
+        div.textContent = text;
+        return div.innerHTML;
+    }
+}
+
+// DOM読み込み完了後に初期化
+document.addEventListener('DOMContentLoaded', () => {
+    console.log('DOM読み込み完了 - KeyboardConnectionManager初期化開始');
+    new KeyboardConnectionManager();
+});

--- a/renderer.js
+++ b/renderer.js
@@ -852,8 +852,186 @@ class KeyboardConnectionManager {
         this.currentPhase = '1.4';
         this.updatePhaseDisplay();
 
-        // TODO: 1.4の実装
-        alert(`素晴らしい！${this.teams.length}チームが作成されました。\n次は「1.4 メンバー割り当て」の実装を進めましょう！`);
+        // 1.4メンバー割り当てセクションを表示
+        this.showMemberAssignmentSection();
+    }
+
+    showMemberAssignmentSection() {
+        // チームセクションを隠す
+        const teamsSection = document.getElementById('teams-section');
+        if (teamsSection) {
+            teamsSection.classList.add('hidden');
+        }
+
+        // 1.4メンバー割り当てセクションを作成
+        const memberAssignmentSection = this.createMemberAssignmentSection();
+
+        // 既存のセクションの後に追加
+        if (teamsSection && teamsSection.parentNode) {
+            teamsSection.parentNode.insertBefore(memberAssignmentSection, teamsSection.nextSibling);
+        }
+
+        this.updateStatus('1.4 メンバー割り当て - チームのターン順を決めましょう');
+        this.addToActivityLog(`[システム] 1.4 メンバー割り当てセクションを表示しました`, 'system');
+    }
+
+    createMemberAssignmentSection() {
+        const section = document.createElement('div');
+        section.className = 'section';
+        section.id = 'member-assignment-section';
+
+        section.innerHTML = `
+            <h3>⚡ メンバー割り当て</h3>
+            <p>各チームの中でのターン順（プレイ順）を決めましょう！</p>
+
+            <div class="turn-order-controls">
+                <h4>ターン順決定方法</h4>
+                <div class="radio-group">
+                    <label class="radio-option">
+                        <input type="radio" name="turnOrderMethod" value="auto" checked>
+                        <span>自動で決める</span>
+                    </label>
+                    <label class="radio-option">
+                        <input type="radio" name="turnOrderMethod" value="manual">
+                        <span>手動で決める</span>
+                    </label>
+                </div>
+                <div class="controls">
+                    <button onclick="keyboardManager.decideTurnOrder()">🎲 ターン順決定</button>
+                    <button onclick="keyboardManager.resetTurnOrder()" class="secondary">🔄 リセット</button>
+                </div>
+            </div>
+
+            <div class="teams-display" id="turn-order-teams-display">
+                ${this.generateTurnOrderTeamsDisplay()}
+            </div>
+
+            <div class="teams-summary" id="turn-order-summary" style="display: none;">
+                <div>
+                    <strong>ターン順決定完了！</strong>
+                    <div style="font-size: 0.9em; color: #666;">全チームのプレイ順が決まりました</div>
+                </div>
+                <div>
+                    <button onclick="keyboardManager.proceedToKeyboardAssignment()" id="proceedToKeyboardBtn" disabled>
+                        1.5 キーボード割り当てへ進む
+                    </button>
+                </div>
+            </div>
+        `;
+
+        return section;
+    }
+
+    generateTurnOrderTeamsDisplay() {
+        let html = '';
+
+        this.teams.forEach((team, index) => {
+            html += `
+                <div class="team-container team-${index + 1}">
+                    <div class="team-header">
+                        <div class="team-name">${this.escapeHtml(team.name)}</div>
+                        <div class="team-member-count">${team.members.length}人</div>
+                    </div>
+                    <div class="team-members" id="team-${team.id}-turn-order">
+                        ${team.members.map((member, memberIndex) => `
+                            <div class="team-member" data-player-id="${member.id}">
+                                <div class="team-member-avatar" style="background: ${member.color};">
+                                    ${this.escapeHtml(member.name.charAt(0))}
+                                </div>
+                                <div class="team-member-name">${this.escapeHtml(member.name)}</div>
+                                <div class="team-member-turn-order">
+                                    <span class="turn-number">${memberIndex + 1}番目</span>
+                                </div>
+                            </div>
+                        `).join('')}
+                    </div>
+                </div>
+            `;
+        });
+
+        return html;
+    }
+
+    decideTurnOrder() {
+        const method = document.querySelector('input[name="turnOrderMethod"]:checked').value;
+
+        if (method === 'auto') {
+            // 自動でターン順をシャッフル
+            this.teams.forEach(team => {
+                // フィッシャー・イェーツアルゴリズムでシャッフル
+                for (let i = team.members.length - 1; i > 0; i--) {
+                    const j = Math.floor(Math.random() * (i + 1));
+                    [team.members[i], team.members[j]] = [team.members[j], team.members[i]];
+                }
+            });
+
+            this.addToActivityLog(`[システム] 全チームのターン順を自動決定しました`, 'system');
+        }
+
+        // 表示を更新
+        this.updateTurnOrderDisplay();
+
+        // 完了状態を更新
+        this.checkTurnOrderCompletion();
+    }
+
+    updateTurnOrderDisplay() {
+        const teamsDisplay = document.getElementById('turn-order-teams-display');
+        if (teamsDisplay) {
+            teamsDisplay.innerHTML = this.generateTurnOrderTeamsDisplay();
+        }
+    }
+
+    resetTurnOrder() {
+        // 各チームのメンバーを元の順序（追加順）に戻す
+        this.teams.forEach(team => {
+            team.members.sort((a, b) => new Date(a.addedAt) - new Date(b.addedAt));
+        });
+
+        this.updateTurnOrderDisplay();
+        this.addToActivityLog(`[システム] ターン順をリセットしました`, 'system');
+
+        // 完了状態をリセット
+        const summary = document.getElementById('turn-order-summary');
+        if (summary) {
+            summary.style.display = 'none';
+        }
+
+        const proceedBtn = document.getElementById('proceedToKeyboardBtn');
+        if (proceedBtn) {
+            proceedBtn.disabled = true;
+        }
+    }
+
+    checkTurnOrderCompletion() {
+        // ターン順が決定されているかチェック（この場合は常にtrue）
+        const isComplete = this.teams.length > 0 && this.teams.every(team => team.members.length > 0);
+
+        const summary = document.getElementById('turn-order-summary');
+        const proceedBtn = document.getElementById('proceedToKeyboardBtn');
+
+        if (summary && proceedBtn) {
+            if (isComplete) {
+                summary.style.display = 'flex';
+                proceedBtn.disabled = false;
+                this.updateStatus('1.4 メンバー割り当て完了 - 次は1.5キーボード割り当てです');
+            } else {
+                summary.style.display = 'none';
+                proceedBtn.disabled = true;
+            }
+        }
+    }
+
+    proceedToKeyboardAssignment() {
+        this.addToActivityLog(`[システム] 1.5 キーボード割り当てへ進みます`, 'system');
+        this.updateStatus('1.5 キーボード割り当ての準備中...');
+
+        // フェーズ切り替え
+        this.currentPhase = '1.5';
+        this.updatePhaseDisplay();
+
+        // TODO: 1.5の実装
+        alert(`ターン順決定完了！\n次は「1.5 キーボード割り当て」の実装を進めましょう！`);
     }
 
     escapeHtml(text) {

--- a/renderer.js
+++ b/renderer.js
@@ -1305,9 +1305,9 @@ class KeyboardConnectionManager {
     }
 
     showTargetCountSection() {
-        const container = document.getElementById('setup-container') || document.querySelector('.setup-panel');
+        const container = document.querySelector('.setup-panel');
         if (!container) {
-            console.error('Setup container not found');
+            console.error('Setup container not found - .setup-panel');
             return;
         }
 
@@ -1448,8 +1448,11 @@ class KeyboardConnectionManager {
     }
 
     showGameStartSection() {
-        const container = document.getElementById('setup-container') || document.querySelector('.setup-panel');
-        if (!container) return;
+        const container = document.querySelector('.setup-panel');
+        if (!container) {
+            console.error('Setup container not found for game start section');
+            return;
+        }
 
         // 既存のゲーム開始セクションを削除
         const existingSection = document.getElementById('game-start-section');

--- a/renderer.js
+++ b/renderer.js
@@ -8,6 +8,10 @@ class KeyboardConnectionManager {
         this.keyboardActivities = new Map();
         this.lastScanTime = Date.now();
 
+        // プレイヤー管理
+        this.players = [];
+        this.currentPhase = '1.1'; // 現在のフェーズ
+
         this.init();
     }
 
@@ -26,6 +30,7 @@ class KeyboardConnectionManager {
         }
 
         this.updateStatus('キーボード検知完了 - タイピングテストを開始できます');
+        this.updatePhaseDisplay(); // 初期フェーズ表示
     }
 
     setupEventListeners() {
@@ -65,6 +70,23 @@ class KeyboardConnectionManager {
         window.toggleMonitoring = () => this.toggleMonitoring();
         window.exportLog = () => this.exportLog();
         window.proceedToNextStep = () => this.proceedToNextStep();
+
+        // プレイヤー管理関数
+        window.addPlayer = () => this.addPlayer();
+        window.removePlayer = (playerId) => this.removePlayer(playerId);
+        window.clearAllPlayers = () => this.clearAllPlayers();
+        window.takePhoto = () => this.takePhoto();
+        window.proceedToTeamCreation = () => this.proceedToTeamCreation();
+
+        // エンターキーでプレイヤー追加
+        const playerNameInput = document.getElementById('playerName');
+        if (playerNameInput) {
+            playerNameInput.addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') {
+                    this.addPlayer();
+                }
+            });
+        }
     }
 
     updateKeyboards(keyboards) {
@@ -330,11 +352,212 @@ class KeyboardConnectionManager {
     }
 
     proceedToNextStep() {
-        this.addToActivityLog('[システム] 次のステップに進みます...', 'system');
-        this.updateStatus('1.2 プレイヤー集合の準備中...');
+        this.addToActivityLog('[システム] 1.2 プレイヤー集合へ進みます...', 'system');
+        this.updateStatus('1.2 プレイヤー集合 - 友達の名前を入力してください');
 
-        // TODO: 次のステップの実装
-        alert('次のステップ「1.2 プレイヤー集合」の実装はまだ準備中です。\n現在は1.1のキーボード接続確認が完了しました！');
+        // フェーズ切り替え
+        this.currentPhase = '1.2';
+        this.updatePhaseDisplay();
+
+        // セクション表示切り替え
+        document.getElementById('keyboard-section').classList.add('hidden');
+        document.getElementById('players-section').classList.remove('hidden');
+
+        // プレイヤー名入力にフォーカス
+        const playerNameInput = document.getElementById('playerName');
+        if (playerNameInput) {
+            playerNameInput.focus();
+        }
+    }
+
+    proceedToTeamCreation() {
+        if (this.players.length < 2) {
+            alert('チームを作るには最低2人の友達が必要です！');
+            return;
+        }
+
+        this.addToActivityLog(`[システム] 1.3 チーム作成へ進みます（${this.players.length}人参加）`, 'system');
+        this.updateStatus('1.3 チーム作成の準備中...');
+
+        // TODO: 1.3の実装
+        alert(`素晴らしい！${this.players.length}人の友達が集まりました。\n次は「1.3 チーム作成」の実装を進めましょう！`);
+    }
+
+    updatePhaseDisplay() {
+        // プログレスインジケーターの更新
+        document.querySelectorAll('.progress-step').forEach(step => {
+            step.classList.remove('completed', 'current');
+        });
+
+        switch (this.currentPhase) {
+            case '1.1':
+                document.getElementById('phase-1-1').classList.add('current');
+                break;
+            case '1.2':
+                document.getElementById('phase-1-1').classList.add('completed');
+                document.getElementById('phase-1-2').classList.add('current');
+                break;
+            case '1.3':
+                document.getElementById('phase-1-1').classList.add('completed');
+                document.getElementById('phase-1-2').classList.add('completed');
+                document.getElementById('phase-1-3').classList.add('current');
+                break;
+        }
+    }
+
+    // プレイヤー管理メソッド
+    addPlayer() {
+        const nameInput = document.getElementById('playerName');
+        const name = nameInput.value.trim();
+
+        if (!name) {
+            alert('なまえを入力してください！');
+            nameInput.focus();
+            return;
+        }
+
+        if (name.length > 10) {
+            alert('なまえは10文字以内で入力してください！');
+            nameInput.focus();
+            return;
+        }
+
+        // 重複チェック
+        if (this.players.some(player => player.name === name)) {
+            alert('同じ名前の友達がすでにいます！');
+            nameInput.focus();
+            return;
+        }
+
+        // 最大人数チェック（8人まで）
+        if (this.players.length >= 8) {
+            alert('最大8人まで参加できます！');
+            return;
+        }
+
+        // プレイヤー追加
+        const player = {
+            id: `player-${Date.now()}`,
+            name: name,
+            avatar: this.generatePlayerAvatar(name),
+            addedAt: new Date().toISOString()
+        };
+
+        this.players.push(player);
+        nameInput.value = '';
+        nameInput.focus();
+
+        this.renderPlayers();
+        this.updatePlayerCount();
+        this.addToActivityLog(`[システム] ${name}さんが参加しました！`, 'system');
+    }
+
+    removePlayer(playerId) {
+        const player = this.players.find(p => p.id === playerId);
+        if (!player) return;
+
+        if (confirm(`${player.name}さんを削除しますか？`)) {
+            this.players = this.players.filter(p => p.id !== playerId);
+            this.renderPlayers();
+            this.updatePlayerCount();
+            this.addToActivityLog(`[システム] ${player.name}さんが離脱しました`, 'system');
+        }
+    }
+
+    clearAllPlayers() {
+        if (this.players.length === 0) {
+            alert('削除する友達がいません！');
+            return;
+        }
+
+        if (confirm('すべての友達を削除しますか？')) {
+            this.players = [];
+            this.renderPlayers();
+            this.updatePlayerCount();
+            this.addToActivityLog('[システム] すべてのプレイヤーを削除しました', 'system');
+        }
+    }
+
+    takePhoto() {
+        // 将来的にはカメラ機能を実装
+        alert('写真撮影機能は将来のバージョンで実装予定です！\n今は名前だけ入力してください。');
+    }
+
+    generatePlayerAvatar(name) {
+        // 名前の最初の文字をアバターとして使用
+        return name.charAt(0).toUpperCase();
+    }
+
+    renderPlayers() {
+        const container = document.getElementById('players-grid');
+        if (!container) return;
+
+        if (this.players.length === 0) {
+            container.innerHTML = `
+                <div style="grid-column: 1 / -1; text-align: center; padding: 40px; color: #718096;">
+                    <div style="font-size: 3em; margin-bottom: 20px;">👥</div>
+                    <div style="font-size: 1.2em; margin-bottom: 10px;">まだ友達がいません</div>
+                    <div>上のフォームから友達を追加してください</div>
+                </div>
+            `;
+            return;
+        }
+
+        container.innerHTML = this.players.map(player => `
+            <div class="player-card">
+                <div class="player-avatar" style="background: ${this.generatePlayerColor(player.id)}">
+                    ${player.avatar}
+                </div>
+                <div class="player-name">${this.escapeHtml(player.name)}</div>
+                <div class="player-actions">
+                    <button onclick="removePlayer('${player.id}')" class="btn-small btn-danger">
+                        🗑️ 削除
+                    </button>
+                </div>
+            </div>
+        `).join('');
+    }
+
+    generatePlayerColor(playerId) {
+        // プレイヤーIDから一意な色を生成
+        const colors = [
+            'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+            'linear-gradient(135deg, #f093fb 0%, #f5576c 100%)',
+            'linear-gradient(135deg, #4facfe 0%, #00f2fe 100%)',
+            'linear-gradient(135deg, #43e97b 0%, #38f9d7 100%)',
+            'linear-gradient(135deg, #fa709a 0%, #fee140 100%)',
+            'linear-gradient(135deg, #a8edea 0%, #fed6e3 100%)',
+            'linear-gradient(135deg, #ffecd2 0%, #fcb69f 100%)',
+            'linear-gradient(135deg, #ff8a80 0%, #ea80fc 100%)'
+        ];
+
+        const hash = playerId.split('').reduce((a, b) => {
+            a = ((a << 5) - a) + b.charCodeAt(0);
+            return a & a;
+        }, 0);
+
+        return colors[Math.abs(hash) % colors.length];
+    }
+
+    updatePlayerCount() {
+        const countElement = document.getElementById('playerCount');
+        const proceedBtn = document.getElementById('proceedToTeamsBtn');
+
+        if (countElement) {
+            countElement.textContent = this.players.length;
+        }
+
+        if (proceedBtn) {
+            if (this.players.length >= 2) {
+                proceedBtn.disabled = false;
+                proceedBtn.style.background = '#48bb78';
+                proceedBtn.textContent = `1.3 チーム作成へ進む（${this.players.length}人）`;
+            } else {
+                proceedBtn.disabled = true;
+                proceedBtn.style.background = '#a0aec0';
+                proceedBtn.textContent = `あと${2 - this.players.length}人必要です`;
+            }
+        }
     }
 
     escapeHtml(text) {

--- a/renderer.js
+++ b/renderer.js
@@ -1030,8 +1030,278 @@ class KeyboardConnectionManager {
         this.currentPhase = '1.5';
         this.updatePhaseDisplay();
 
-        // TODO: 1.5の実装
-        alert(`ターン順決定完了！\n次は「1.5 キーボード割り当て」の実装を進めましょう！`);
+        // 1.5キーボード割り当てセクションを表示
+        this.showKeyboardAssignmentSection();
+    }
+
+    showKeyboardAssignmentSection() {
+        // メンバー割り当てセクションを隠す
+        const memberAssignmentSection = document.getElementById('member-assignment-section');
+        if (memberAssignmentSection) {
+            memberAssignmentSection.classList.add('hidden');
+        }
+
+        // 1.5キーボード割り当てセクションを作成
+        const keyboardAssignmentSection = this.createKeyboardAssignmentSection();
+
+        // 既存のセクションの後に追加
+        if (memberAssignmentSection && memberAssignmentSection.parentNode) {
+            memberAssignmentSection.parentNode.insertBefore(keyboardAssignmentSection, memberAssignmentSection.nextSibling);
+        }
+
+        this.updateStatus('1.5 キーボード割り当て - 各チームにキーボードを割り当てましょう');
+        this.addToActivityLog(`[システム] 1.5 キーボード割り当てセクションを表示しました`, 'system');
+    }
+
+    createKeyboardAssignmentSection() {
+        const section = document.createElement('div');
+        section.className = 'section';
+        section.id = 'keyboard-assignment-section';
+
+        section.innerHTML = `
+            <h3>⌨️ キーボード割り当て</h3>
+            <p>各チームに使用するキーボードを割り当てましょう！</p>
+
+            <div class="keyboard-status-overview">
+                <div class="keyboard-summary">
+                    <span>検知済みキーボード: <strong id="available-keyboard-count">${this.keyboards.length}</strong>台</span>
+                    <span>必要キーボード: <strong id="required-keyboard-count">${this.teams.length}</strong>台</span>
+                    <button onclick="keyboardManager.refreshKeyboards()" class="btn-small">🔄 再検索</button>
+                </div>
+                ${this.keyboards.length < this.teams.length ?
+                    `<div class="warning-message">⚠️ キーボードが不足しています。必要数: ${this.teams.length}台、検知済み: ${this.keyboards.length}台</div>` :
+                    ''}
+            </div>
+
+            <div class="assignment-controls">
+                <h4>割り当て方法</h4>
+                <div class="radio-group">
+                    <label class="radio-option">
+                        <input type="radio" name="keyboardAssignmentMethod" value="auto" checked>
+                        <span>自動で割り当て</span>
+                    </label>
+                    <label class="radio-option">
+                        <input type="radio" name="keyboardAssignmentMethod" value="manual">
+                        <span>手動で割り当て</span>
+                    </label>
+                </div>
+                <div class="controls">
+                    <button onclick="keyboardManager.assignKeyboards()" id="assignKeyboardsBtn">🎯 キーボード割り当て</button>
+                    <button onclick="keyboardManager.clearKeyboardAssignments()" class="secondary">🔄 割り当てクリア</button>
+                </div>
+            </div>
+
+            <div class="keyboard-assignment-display" id="keyboard-assignment-display">
+                ${this.generateKeyboardAssignmentDisplay()}
+            </div>
+
+            <div class="assignment-summary" id="keyboard-assignment-summary" style="display: none;">
+                <div>
+                    <strong>キーボード割り当て完了！</strong>
+                    <div style="font-size: 0.9em; color: #666;">全チームにキーボードが割り当てられました</div>
+                </div>
+                <div>
+                    <button onclick="keyboardManager.proceedToTargetSetting()" id="proceedToTargetBtn" disabled>
+                        1.6 お題数設定へ進む
+                    </button>
+                </div>
+            </div>
+        `;
+
+        return section;
+    }
+
+    generateKeyboardAssignmentDisplay() {
+        let html = '';
+
+        // チームとキーボードの表示
+        html += '<div class="teams-keyboards-grid">';
+
+        this.teams.forEach((team, index) => {
+            const assignedKeyboard = this.keyboards.find(kb => kb.assignedTeamId === team.id);
+
+            html += `
+                <div class="team-keyboard-card team-${index + 1}">
+                    <div class="team-info">
+                        <div class="team-name">${this.escapeHtml(team.name)}</div>
+                        <div class="team-members-count">${team.members.length}人</div>
+                        <div class="team-members-preview">
+                            ${team.members.slice(0, 3).map(member =>
+                                `<span class="member-avatar" style="background: ${member.color};">${this.escapeHtml(member.name.charAt(0))}</span>`
+                            ).join('')}
+                            ${team.members.length > 3 ? `<span class="member-more">+${team.members.length - 3}</span>` : ''}
+                        </div>
+                    </div>
+                    <div class="keyboard-assignment">
+                        <div class="assignment-arrow">↓</div>
+                        <div class="keyboard-slot" data-team-id="${team.id}">
+                            ${assignedKeyboard ? `
+                                <div class="assigned-keyboard">
+                                    <div class="keyboard-name">${this.escapeHtml(assignedKeyboard.name)}</div>
+                                    <div class="keyboard-info">ID: ${this.escapeHtml(assignedKeyboard.id)}</div>
+                                    <button onclick="keyboardManager.unassignKeyboard('${team.id}')" class="btn-mini btn-danger">×</button>
+                                </div>
+                            ` : `
+                                <div class="unassigned-slot">
+                                    <div class="slot-placeholder">キーボード未割り当て</div>
+                                    <select onchange="keyboardManager.assignSpecificKeyboard('${team.id}', this.value)" class="keyboard-selector">
+                                        <option value="">選択してください</option>
+                                        ${this.keyboards.filter(kb => !kb.assignedTeamId).map(kb =>
+                                            `<option value="${kb.id}">${this.escapeHtml(kb.name)} (${kb.id})</option>`
+                                        ).join('')}
+                                    </select>
+                                </div>
+                            `}
+                        </div>
+                    </div>
+                </div>
+            `;
+        });
+
+        html += '</div>';
+
+        // 未割り当てキーボード一覧
+        const unassignedKeyboards = this.keyboards.filter(kb => !kb.assignedTeamId);
+        if (unassignedKeyboards.length > 0) {
+            html += `
+                <div class="unassigned-keyboards">
+                    <h4>未割り当てキーボード</h4>
+                    <div class="keyboard-list">
+                        ${unassignedKeyboards.map(kb => `
+                            <div class="keyboard-item">
+                                <div class="keyboard-name">${this.escapeHtml(kb.name)}</div>
+                                <div class="keyboard-id">ID: ${this.escapeHtml(kb.id)}</div>
+                                <div class="keyboard-status ${kb.connected ? 'connected' : 'disconnected'}">
+                                    ${kb.connected ? '🟢 接続中' : '🔴 未接続'}
+                                </div>
+                            </div>
+                        `).join('')}
+                    </div>
+                </div>
+            `;
+        }
+
+        return html;
+    }
+
+    assignKeyboards() {
+        const method = document.querySelector('input[name="keyboardAssignmentMethod"]:checked').value;
+
+        if (this.keyboards.length < this.teams.length) {
+            alert(`キーボードが不足しています。\n必要: ${this.teams.length}台、検知済み: ${this.keyboards.length}台\n\nキーボードを追加接続してから「🔄 再検索」を押してください。`);
+            return;
+        }
+
+        // 既存の割り当てをクリア
+        this.keyboards.forEach(kb => delete kb.assignedTeamId);
+
+        if (method === 'auto') {
+            // 自動割り当て: 接続済みキーボードを優先して割り当て
+            const connectedKeyboards = this.keyboards.filter(kb => kb.connected);
+            const disconnectedKeyboards = this.keyboards.filter(kb => !kb.connected);
+            const availableKeyboards = [...connectedKeyboards, ...disconnectedKeyboards];
+
+            this.teams.forEach((team, index) => {
+                if (index < availableKeyboards.length) {
+                    availableKeyboards[index].assignedTeamId = team.id;
+                }
+            });
+
+            this.addToActivityLog(`[システム] キーボードを自動割り当てしました`, 'system');
+        }
+
+        // 表示を更新
+        this.updateKeyboardAssignmentDisplay();
+
+        // 完了状態を確認
+        this.checkKeyboardAssignmentCompletion();
+    }
+
+    assignSpecificKeyboard(teamId, keyboardId) {
+        if (!keyboardId) return;
+
+        const keyboard = this.keyboards.find(kb => kb.id === keyboardId);
+        const team = this.teams.find(t => t.id === teamId);
+
+        if (keyboard && team) {
+            // 既存の割り当てをクリア
+            keyboard.assignedTeamId = teamId;
+
+            this.updateKeyboardAssignmentDisplay();
+            this.checkKeyboardAssignmentCompletion();
+
+            this.addToActivityLog(`[システム] ${team.name}に${keyboard.name}を割り当てました`, 'system');
+        }
+    }
+
+    unassignKeyboard(teamId) {
+        const keyboard = this.keyboards.find(kb => kb.assignedTeamId === teamId);
+        const team = this.teams.find(t => t.id === teamId);
+
+        if (keyboard && team) {
+            delete keyboard.assignedTeamId;
+
+            this.updateKeyboardAssignmentDisplay();
+            this.checkKeyboardAssignmentCompletion();
+
+            this.addToActivityLog(`[システム] ${team.name}から${keyboard.name}の割り当てを解除しました`, 'system');
+        }
+    }
+
+    clearKeyboardAssignments() {
+        this.keyboards.forEach(kb => delete kb.assignedTeamId);
+
+        this.updateKeyboardAssignmentDisplay();
+        this.checkKeyboardAssignmentCompletion();
+
+        this.addToActivityLog(`[システム] すべてのキーボード割り当てをクリアしました`, 'system');
+    }
+
+    updateKeyboardAssignmentDisplay() {
+        const display = document.getElementById('keyboard-assignment-display');
+        if (display) {
+            display.innerHTML = this.generateKeyboardAssignmentDisplay();
+        }
+
+        // キーボード数表示を更新
+        const availableCount = document.getElementById('available-keyboard-count');
+        const requiredCount = document.getElementById('required-keyboard-count');
+        if (availableCount) availableCount.textContent = this.keyboards.length;
+        if (requiredCount) requiredCount.textContent = this.teams.length;
+    }
+
+    checkKeyboardAssignmentCompletion() {
+        const assignedTeams = this.teams.filter(team =>
+            this.keyboards.some(kb => kb.assignedTeamId === team.id)
+        );
+
+        const isComplete = assignedTeams.length === this.teams.length;
+
+        const summary = document.getElementById('keyboard-assignment-summary');
+        const proceedBtn = document.getElementById('proceedToTargetBtn');
+
+        if (summary && proceedBtn) {
+            if (isComplete) {
+                summary.style.display = 'flex';
+                proceedBtn.disabled = false;
+                this.updateStatus('1.5 キーボード割り当て完了 - 次は1.6お題数設定です');
+            } else {
+                summary.style.display = 'none';
+                proceedBtn.disabled = true;
+            }
+        }
+    }
+
+    proceedToTargetSetting() {
+        this.addToActivityLog(`[システム] 1.6 お題数設定へ進みます`, 'system');
+        this.updateStatus('1.6 お題数設定の準備中...');
+
+        // フェーズ切り替え
+        this.currentPhase = '1.6';
+        this.updatePhaseDisplay();
+
+        // TODO: 1.6の実装
+        alert(`キーボード割り当て完了！\n次は「1.6 お題数設定」の実装を進めましょう！`);
     }
 
     escapeHtml(text) {

--- a/src/__tests__/preload.simple.test.ts
+++ b/src/__tests__/preload.simple.test.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment node
+ * @jest-environment jsdom
  */
 
 // Electronモジュールをモック化
@@ -23,24 +23,21 @@ describe('preload.ts', () => {
         require('../preload');
     });
 
-    it('should expose keyboardGameAPI to main world', () => {
-        expect(mockContextBridge.exposeInMainWorld).toHaveBeenCalledWith(
-            'keyboardGameAPI',
-            expect.objectContaining({
-                onKeyboardInput: expect.any(Function),
-                startGame: expect.any(Function),
-                stopGame: expect.any(Function),
-                getKeyboards: expect.any(Function)
-            })
-        );
+    it('should expose keyboardGameAPI to window', () => {
+        // preload.tsは直接windowに割り当てるので、windowオブジェクトをテストする
+        expect((window as any).keyboardGameAPI).toBeDefined();
+        expect((window as any).keyboardGameAPI).toHaveProperty('onKeyboardInput');
+        expect((window as any).keyboardGameAPI).toHaveProperty('startGame');
+        expect((window as any).keyboardGameAPI).toHaveProperty('stopGame');
+        expect((window as any).keyboardGameAPI).toHaveProperty('getKeyboards');
     });
 
     it('should have correct API methods', () => {
-        const exposedAPI = mockContextBridge.exposeInMainWorld.mock.calls[0][1];
-        
-        expect(typeof exposedAPI.onKeyboardInput).toBe('function');
-        expect(typeof exposedAPI.startGame).toBe('function');
-        expect(typeof exposedAPI.stopGame).toBe('function');
-        expect(typeof exposedAPI.getKeyboards).toBe('function');
+        const api = (window as any).keyboardGameAPI;
+
+        expect(typeof api.onKeyboardInput).toBe('function');
+        expect(typeof api.startGame).toBe('function');
+        expect(typeof api.stopGame).toBe('function');
+        expect(typeof api.getKeyboards).toBe('function');
     });
 });

--- a/src/config/dev-presets.json
+++ b/src/config/dev-presets.json
@@ -1,0 +1,104 @@
+{
+  "_comment": "開発・デバッグ用プリセット設定",
+  "presets": {
+    "quick-2team": {
+      "name": "クイック2チーム",
+      "description": "2チームでの動作確認用",
+      "teamCount": 2,
+      "difficulty": "easy",
+      "gameDurationSeconds": 30,
+      "wordCategory": "animals",
+      "players": [
+        "テストプレイヤー1",
+        "テストプレイヤー2",
+        "テストプレイヤー3",
+        "テストプレイヤー4"
+      ],
+      "teamAssignmentStrategy": "sequential",
+      "turnOrderStrategy": "sequential",
+      "soundSettings": {
+        "masterVolume": 50,
+        "soundEffectsEnabled": true,
+        "typingSoundEnabled": true,
+        "backgroundMusicEnabled": false
+      }
+    },
+    "multi-team": {
+      "name": "マルチチーム",
+      "description": "多チームでの動作確認用",
+      "teamCount": 4,
+      "difficulty": "normal",
+      "gameDurationSeconds": 60,
+      "wordCategory": "mixed",
+      "players": [
+        "プレイヤー1",
+        "プレイヤー2",
+        "プレイヤー3",
+        "プレイヤー4",
+        "プレイヤー5",
+        "プレイヤー6",
+        "プレイヤー7",
+        "プレイヤー8"
+      ],
+      "teamAssignmentStrategy": "random",
+      "turnOrderStrategy": "random",
+      "soundSettings": {
+        "masterVolume": 70,
+        "soundEffectsEnabled": true,
+        "typingSoundEnabled": true,
+        "backgroundMusicEnabled": true
+      }
+    },
+    "minimal": {
+      "name": "最小構成",
+      "description": "最小限の設定でのテスト用",
+      "teamCount": 2,
+      "difficulty": "easy",
+      "gameDurationSeconds": 15,
+      "wordCategory": "colors",
+      "players": [
+        "Player1",
+        "Player2"
+      ],
+      "teamAssignmentStrategy": "sequential",
+      "turnOrderStrategy": "sequential",
+      "soundSettings": {
+        "masterVolume": 0,
+        "soundEffectsEnabled": false,
+        "typingSoundEnabled": false,
+        "backgroundMusicEnabled": false
+      }
+    },
+    "full-config": {
+      "name": "フル機能テスト",
+      "description": "すべての機能を有効にしたテスト用",
+      "teamCount": 6,
+      "difficulty": "hard",
+      "gameDurationSeconds": 120,
+      "wordCategory": "school",
+      "players": [
+        "あきら",
+        "かずき",
+        "さくら",
+        "たろう",
+        "なおき",
+        "はなこ",
+        "みさき",
+        "ゆうた",
+        "りな",
+        "わかな",
+        "そうた",
+        "えみ"
+      ],
+      "teamAssignmentStrategy": "manual",
+      "turnOrderStrategy": "alphabetical",
+      "soundSettings": {
+        "masterVolume": 100,
+        "soundEffectsEnabled": true,
+        "typingSoundEnabled": true,
+        "backgroundMusicEnabled": true
+      }
+    }
+  },
+  "defaultPreset": "quick-2team"
+}

--- a/src/domain/entities/GameConfig.spec.ts
+++ b/src/domain/entities/GameConfig.spec.ts
@@ -1,5 +1,5 @@
-import { GameConfig } from './GameConfig.js';
-import { DifficultyLevel, WordCategory } from '../../shared/types/GameConfig.js';
+import { GameConfig } from './GameConfig';
+import { DifficultyLevel, WordCategory } from '../../shared/types/GameConfig';
 
 describe('GameConfig', () => {
   describe('constructor', () => {

--- a/src/domain/entities/Player.spec.ts
+++ b/src/domain/entities/Player.spec.ts
@@ -1,0 +1,139 @@
+import { Player } from './Player';
+
+describe('Player', () => {
+  describe('constructor', () => {
+    it('should create player with valid name', () => {
+      const player = new Player('太郎');
+
+      expect(player.name).toBe('太郎');
+      expect(player.id).toBeDefined();
+      expect(player.id.length).toBeGreaterThan(0);
+      expect(player.createdAt).toBeDefined();
+    });
+
+    it('should create player with custom ID', () => {
+      const customId = 'custom-player-id';
+      const player = new Player('太郎', customId);
+
+      expect(player.id).toBe(customId);
+      expect(player.name).toBe('太郎');
+    });
+
+    it('should trim player name', () => {
+      const player = new Player('  太郎  ');
+
+      expect(player.name).toBe('太郎');
+    });
+
+    it('should throw error for empty name', () => {
+      expect(() => new Player('')).toThrow('プレイヤー名は必須です');
+      expect(() => new Player('   ')).toThrow('プレイヤー名は必須です');
+    });
+
+    it('should throw error for name too long', () => {
+      const longName = 'あ'.repeat(21);
+
+      expect(() => new Player(longName)).toThrow('プレイヤー名は20文字以内で入力してください');
+    });
+
+    it('should allow name with exactly 20 characters', () => {
+      const maxLengthName = 'あ'.repeat(20);
+      const player = new Player(maxLengthName);
+
+      expect(player.name).toBe(maxLengthName);
+    });
+  });
+
+  describe('updateName', () => {
+    it('should update player name', () => {
+      const player = new Player('太郎');
+      const updatedPlayer = player.updateName('次郎');
+
+      expect(updatedPlayer.name).toBe('次郎');
+      expect(updatedPlayer.id).toBe(player.id); // IDは変更されない
+      expect(updatedPlayer.createdAt).toBe(player.createdAt); // 作成日時も変更されない
+    });
+
+    it('should trim updated name', () => {
+      const player = new Player('太郎');
+      const updatedPlayer = player.updateName('  次郎  ');
+
+      expect(updatedPlayer.name).toBe('次郎');
+    });
+
+    it('should throw error for empty updated name', () => {
+      const player = new Player('太郎');
+
+      expect(() => player.updateName('')).toThrow('プレイヤー名は必須です');
+      expect(() => player.updateName('   ')).toThrow('プレイヤー名は必須です');
+    });
+  });
+
+  describe('toPlainObject', () => {
+    it('should return plain object representation', () => {
+      const player = new Player('太郎', 'test-id');
+      const plainObject = player.toPlainObject();
+
+      expect(plainObject).toEqual({
+        id: 'test-id',
+        name: '太郎',
+        createdAt: expect.any(String)
+      });
+    });
+  });
+
+  describe('fromPlainObject', () => {
+    it('should create player from plain object', () => {
+      const plainData = {
+        id: 'test-id',
+        name: '太郎',
+        createdAt: '2023-01-01T00:00:00.000Z'
+      };
+
+      const player = Player.fromPlainObject(plainData);
+
+      expect(player.id).toBe('test-id');
+      expect(player.name).toBe('太郎');
+      expect(player.createdAt).toBe('2023-01-01T00:00:00.000Z');
+    });
+
+    it('should validate plain object data', () => {
+      const invalidData = {
+        id: '',
+        name: '太郎',
+        createdAt: '2023-01-01T00:00:00.000Z'
+      };
+
+      expect(() => Player.fromPlainObject(invalidData)).toThrow('プレイヤーIDは必須です');
+    });
+  });
+
+  describe('createMultiple', () => {
+    it('should create multiple players', () => {
+      const names = ['太郎', '花子', '次郎'];
+      const players = Player.createMultiple(names);
+
+      expect(players).toHaveLength(3);
+      expect(players[0].name).toBe('太郎');
+      expect(players[1].name).toBe('花子');
+      expect(players[2].name).toBe('次郎');
+
+      // 各プレイヤーのIDがユニークかチェック
+      const ids = players.map(p => p.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    it('should create empty array for empty names', () => {
+      const players = Player.createMultiple([]);
+
+      expect(players).toHaveLength(0);
+    });
+
+    it('should throw error for invalid names', () => {
+      const names = ['太郎', '', '次郎'];
+
+      expect(() => Player.createMultiple(names)).toThrow('プレイヤー名は必須です');
+    });
+  });
+});

--- a/src/domain/entities/Player.ts
+++ b/src/domain/entities/Player.ts
@@ -1,0 +1,82 @@
+import { Player as IPlayer } from '../../shared/types/GameConfig';
+import { generateId } from '../../shared/utils/seeded-random';
+
+/**
+ * プレイヤードメインエンティティ
+ * Phase 1.4: プレイヤー情報の管理を担当
+ */
+export class Player {
+  private readonly playerData: IPlayer;
+
+  constructor(name: string, id?: string) {
+    this.playerData = {
+      id: id || generateId(),
+      name: name.trim(),
+      createdAt: new Date().toISOString()
+    };
+
+    this.validatePlayer();
+  }
+
+  // Getters
+  get id(): string { return this.playerData.id; }
+  get name(): string { return this.playerData.name; }
+  get createdAt(): string { return this.playerData.createdAt; }
+
+  /**
+   * プレイヤー名を更新
+   */
+  updateName(name: string): Player {
+    if (!name.trim()) {
+      throw new Error('プレイヤー名は必須です');
+    }
+
+    const player = Object.create(Player.prototype);
+    player.playerData = {
+      ...this.playerData,
+      name: name.trim()
+    };
+    return player;
+  }
+
+  /**
+   * プレーンオブジェクトとして取得
+   */
+  toPlainObject(): IPlayer {
+    return { ...this.playerData };
+  }
+
+  /**
+   * プレイヤーの妥当性検証（内部用）
+   */
+  private validatePlayer(): void {
+    if (!this.playerData.id.trim()) {
+      throw new Error('プレイヤーIDは必須です');
+    }
+
+    if (!this.playerData.name.trim()) {
+      throw new Error('プレイヤー名は必須です');
+    }
+
+    if (this.playerData.name.length > 20) {
+      throw new Error('プレイヤー名は20文字以内で入力してください');
+    }
+  }
+
+  /**
+   * 静的ファクトリーメソッド: プレーンオブジェクトから作成
+   */
+  static fromPlainObject(data: IPlayer): Player {
+    const player = Object.create(Player.prototype);
+    player.playerData = { ...data };
+    player.validatePlayer();
+    return player;
+  }
+
+  /**
+   * 静的ファクトリーメソッド: 複数のプレイヤーを一括作成
+   */
+  static createMultiple(names: string[]): Player[] {
+    return names.map(name => new Player(name));
+  }
+}

--- a/src/domain/entities/Team.spec.ts
+++ b/src/domain/entities/Team.spec.ts
@@ -1,0 +1,254 @@
+import { Team } from './Team';
+import { Player, TeamSettings } from '../../shared/types/GameConfig';
+
+describe('Team', () => {
+  const mockTeamSettings: TeamSettings = {
+    id: 1,
+    name: 'チーム1',
+    color: '#ff6b6b',
+    assignedKeyboardId: 'keyboard-1'
+  };
+
+  const mockPlayers: Player[] = [
+    {
+      id: 'player-1',
+      name: '太郎',
+      createdAt: '2023-01-01T00:00:00.000Z'
+    },
+    {
+      id: 'player-2',
+      name: '花子',
+      createdAt: '2023-01-01T00:00:00.000Z'
+    },
+    {
+      id: 'player-3',
+      name: '次郎',
+      createdAt: '2023-01-01T00:00:00.000Z'
+    }
+  ];
+
+  describe('constructor', () => {
+    it('should create team with members', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1]]);
+
+      expect(team.id).toBe(1);
+      expect(team.name).toBe('チーム1');
+      expect(team.color).toBe('#ff6b6b');
+      expect(team.assignedKeyboardId).toBe('keyboard-1');
+      expect(team.memberCount).toBe(2);
+      expect(team.currentTurnIndex).toBe(0);
+    });
+
+    it('should create team without members', () => {
+      const team = new Team(mockTeamSettings);
+
+      expect(team.memberCount).toBe(0);
+      expect(team.currentTurnIndex).toBe(0);
+      expect(team.getCurrentPlayer()).toBeNull();
+    });
+
+    it('should throw error for invalid team ID', () => {
+      const invalidSettings = { ...mockTeamSettings, id: 0 };
+
+      expect(() => new Team(invalidSettings)).toThrow('チームIDは正の数である必要があります');
+    });
+
+    it('should throw error for empty team name', () => {
+      const invalidSettings = { ...mockTeamSettings, name: '' };
+
+      expect(() => new Team(invalidSettings)).toThrow('チーム名は必須です');
+    });
+  });
+
+  describe('getCurrentPlayer', () => {
+    it('should return current player', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1]]);
+      const currentPlayer = team.getCurrentPlayer();
+
+      expect(currentPlayer).toEqual(mockPlayers[0]);
+    });
+
+    it('should return null for team without members', () => {
+      const team = new Team(mockTeamSettings);
+      const currentPlayer = team.getCurrentPlayer();
+
+      expect(currentPlayer).toBeNull();
+    });
+  });
+
+  describe('nextTurn', () => {
+    it('should advance to next player', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1]]);
+      const nextTurnTeam = team.nextTurn();
+
+      expect(nextTurnTeam.currentTurnIndex).toBe(1);
+      expect(nextTurnTeam.getCurrentPlayer()).toEqual(mockPlayers[1]);
+    });
+
+    it('should wrap around to first player', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1]]);
+      const nextTurnTeam = team.nextTurn().nextTurn(); // 2回進める
+
+      expect(nextTurnTeam.currentTurnIndex).toBe(0);
+      expect(nextTurnTeam.getCurrentPlayer()).toEqual(mockPlayers[0]);
+    });
+
+    it('should not change for team without members', () => {
+      const team = new Team(mockTeamSettings);
+      const nextTurnTeam = team.nextTurn();
+
+      expect(nextTurnTeam.currentTurnIndex).toBe(0);
+      expect(nextTurnTeam.getCurrentPlayer()).toBeNull();
+    });
+  });
+
+  describe('addMember', () => {
+    it('should add new member', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+      const updatedTeam = team.addMember(mockPlayers[1]);
+
+      expect(updatedTeam.memberCount).toBe(2);
+      expect(updatedTeam.hasMember(mockPlayers[1].id)).toBe(true);
+    });
+
+    it('should throw error when adding duplicate member', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+
+      expect(() => team.addMember(mockPlayers[0]))
+        .toThrow('プレイヤー "太郎" は既にチームに参加しています');
+    });
+  });
+
+  describe('removeMember', () => {
+    it('should remove member', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1]]);
+      const updatedTeam = team.removeMember(mockPlayers[1].id);
+
+      expect(updatedTeam.memberCount).toBe(1);
+      expect(updatedTeam.hasMember(mockPlayers[1].id)).toBe(false);
+      expect(updatedTeam.hasMember(mockPlayers[0].id)).toBe(true);
+    });
+
+    it('should adjust current turn index when removing current player', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1], mockPlayers[2]]);
+      const nextTurnTeam = team.nextTurn(); // current index = 1 (player-2)
+      const updatedTeam = nextTurnTeam.removeMember(mockPlayers[1].id);
+
+      expect(updatedTeam.memberCount).toBe(2);
+      expect(updatedTeam.currentTurnIndex).toBe(0);
+      expect(updatedTeam.getCurrentPlayer()).toEqual(mockPlayers[0]);
+    });
+
+    it('should throw error when removing non-existent member', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+
+      expect(() => team.removeMember('non-existent'))
+        .toThrow('プレイヤーID "non-existent" はチームに参加していません');
+    });
+  });
+
+  describe('reorderMembers', () => {
+    it('should reorder members correctly', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1], mockPlayers[2]]);
+      const newOrder = [mockPlayers[2].id, mockPlayers[0].id, mockPlayers[1].id];
+      const reorderedTeam = team.reorderMembers(newOrder);
+
+      const members = reorderedTeam.members;
+      expect(members[0].player).toEqual(mockPlayers[2]);
+      expect(members[1].player).toEqual(mockPlayers[0]);
+      expect(members[2].player).toEqual(mockPlayers[1]);
+    });
+
+    it('should throw error for invalid member list', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1]]);
+      const invalidOrder = [mockPlayers[0].id, 'non-existent'];
+
+      expect(() => team.reorderMembers(invalidOrder))
+        .toThrow('新しいターン順に含まれるメンバーIDが現在のメンバーと一致しません');
+    });
+  });
+
+  describe('updateName', () => {
+    it('should update team name', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+      const updatedTeam = team.updateName('新しいチーム名');
+
+      expect(updatedTeam.name).toBe('新しいチーム名');
+    });
+
+    it('should throw error for empty name', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+
+      expect(() => team.updateName(''))
+        .toThrow('チーム名は必須です');
+    });
+  });
+
+  describe('isReadyForGame', () => {
+    it('should return ready when team has members and keyboard', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+      const result = team.isReadyForGame();
+
+      expect(result.ready).toBe(true);
+      expect(result.issues).toHaveLength(0);
+    });
+
+    it('should return not ready when team has no members', () => {
+      const team = new Team(mockTeamSettings);
+      const result = team.isReadyForGame();
+
+      expect(result.ready).toBe(false);
+      expect(result.issues).toContain('チームにメンバーが割り当てられていません');
+    });
+
+    it('should return not ready when team has no keyboard', () => {
+      const settingsWithoutKeyboard = { ...mockTeamSettings, assignedKeyboardId: undefined };
+      const team = new Team(settingsWithoutKeyboard, [mockPlayers[0]]);
+      const result = team.isReadyForGame();
+
+      expect(result.ready).toBe(false);
+      expect(result.issues).toContain('チームにキーボードが割り当てられていません');
+    });
+  });
+
+  describe('hasMember', () => {
+    it('should return true for existing member', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+
+      expect(team.hasMember(mockPlayers[0].id)).toBe(true);
+    });
+
+    it('should return false for non-existing member', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0]]);
+
+      expect(team.hasMember('non-existent')).toBe(false);
+    });
+  });
+
+  describe('toPlainObject', () => {
+    it('should return plain object representation', () => {
+      const team = new Team(mockTeamSettings, [mockPlayers[0], mockPlayers[1]]);
+      const plainObject = team.toPlainObject();
+
+      expect(plainObject).toEqual({
+        id: 1,
+        name: 'チーム1',
+        color: '#ff6b6b',
+        assignedKeyboardId: 'keyboard-1',
+        members: expect.arrayContaining([
+          expect.objectContaining({
+            player: mockPlayers[0],
+            turnOrder: 0,
+            joinedAt: expect.any(String)
+          }),
+          expect.objectContaining({
+            player: mockPlayers[1],
+            turnOrder: 1,
+            joinedAt: expect.any(String)
+          })
+        ]),
+        currentTurnIndex: 0
+      });
+    });
+  });
+});

--- a/src/domain/entities/Team.ts
+++ b/src/domain/entities/Team.ts
@@ -1,0 +1,257 @@
+import { Player as IPlayer, TeamMember, TeamWithMembers, TeamSettings } from '../../shared/types/GameConfig';
+
+/**
+ * チームドメインエンティティ
+ * Phase 1.4: メンバー割り当てとターン順管理を担当
+ */
+export class Team {
+  private readonly teamData: TeamWithMembers;
+
+  constructor(teamSettings: TeamSettings, members: IPlayer[] = []) {
+    this.teamData = {
+      ...teamSettings,
+      members: this.assignMembers(members),
+      currentTurnIndex: 0
+    };
+
+    this.validateTeam();
+  }
+
+  // Getters
+  get id(): number { return this.teamData.id; }
+  get name(): string { return this.teamData.name; }
+  get color(): string { return this.teamData.color; }
+  get assignedKeyboardId(): string | undefined { return this.teamData.assignedKeyboardId; }
+  get members(): readonly TeamMember[] { return [...this.teamData.members]; }
+  get currentTurnIndex(): number { return this.teamData.currentTurnIndex; }
+  get memberCount(): number { return this.teamData.members.length; }
+
+  /**
+   * 現在のターンのプレイヤーを取得
+   */
+  getCurrentPlayer(): IPlayer | null {
+    if (this.teamData.members.length === 0) return null;
+    return this.teamData.members[this.teamData.currentTurnIndex]?.player || null;
+  }
+
+  /**
+   * 次のプレイヤーのターンに進む
+   */
+  nextTurn(): Team {
+    if (this.teamData.members.length === 0) return this;
+
+    const nextIndex = (this.teamData.currentTurnIndex + 1) % this.teamData.members.length;
+
+    return new Team(
+      {
+        id: this.teamData.id,
+        name: this.teamData.name,
+        color: this.teamData.color,
+        assignedKeyboardId: this.teamData.assignedKeyboardId
+      },
+      this.teamData.members.map(m => m.player)
+    ).updateCurrentTurn(nextIndex);
+  }
+
+  /**
+   * メンバーを追加
+   */
+  addMember(player: IPlayer): Team {
+    if (this.hasMember(player.id)) {
+      throw new Error(`プレイヤー "${player.name}" は既にチームに参加しています`);
+    }
+
+    const newMembers = [...this.teamData.members.map(m => m.player), player];
+
+    return new Team(
+      {
+        id: this.teamData.id,
+        name: this.teamData.name,
+        color: this.teamData.color,
+        assignedKeyboardId: this.teamData.assignedKeyboardId
+      },
+      newMembers
+    );
+  }
+
+  /**
+   * メンバーを削除
+   */
+  removeMember(playerId: string): Team {
+    const memberExists = this.hasMember(playerId);
+    if (!memberExists) {
+      throw new Error(`プレイヤーID "${playerId}" はチームに参加していません`);
+    }
+
+    const newMembers = this.teamData.members
+      .filter(m => m.player.id !== playerId)
+      .map(m => m.player);
+
+    // 削除されたメンバーのインデックスがcurrentTurnIndexより小さい場合、調整が必要
+    const removedIndex = this.teamData.members.findIndex(m => m.player.id === playerId);
+    let newCurrentTurnIndex = this.teamData.currentTurnIndex;
+
+    if (removedIndex <= this.teamData.currentTurnIndex && newMembers.length > 0) {
+      newCurrentTurnIndex = Math.max(0, this.teamData.currentTurnIndex - 1);
+      newCurrentTurnIndex = newCurrentTurnIndex % newMembers.length;
+    } else if (newMembers.length === 0) {
+      newCurrentTurnIndex = 0;
+    }
+
+    return new Team(
+      {
+        id: this.teamData.id,
+        name: this.teamData.name,
+        color: this.teamData.color,
+        assignedKeyboardId: this.teamData.assignedKeyboardId
+      },
+      newMembers
+    ).updateCurrentTurn(newCurrentTurnIndex);
+  }
+
+  /**
+   * メンバーのターン順を変更
+   */
+  reorderMembers(newOrder: string[]): Team {
+    // 現在のメンバーIDとnewOrderの整合性チェック
+    const currentMemberIds = new Set(this.teamData.members.map(m => m.player.id));
+    const newOrderIds = new Set(newOrder);
+
+    if (currentMemberIds.size !== newOrderIds.size ||
+        ![...currentMemberIds].every(id => newOrderIds.has(id))) {
+      throw new Error('新しいターン順に含まれるメンバーIDが現在のメンバーと一致しません');
+    }
+
+    const reorderedPlayers = newOrder.map(playerId => {
+      const member = this.teamData.members.find(m => m.player.id === playerId);
+      if (!member) {
+        throw new Error(`プレイヤーID "${playerId}" が見つかりません`);
+      }
+      return member.player;
+    });
+
+    return new Team(
+      {
+        id: this.teamData.id,
+        name: this.teamData.name,
+        color: this.teamData.color,
+        assignedKeyboardId: this.teamData.assignedKeyboardId
+      },
+      reorderedPlayers
+    );
+  }
+
+  /**
+   * チーム名を更新
+   */
+  updateName(name: string): Team {
+    if (!name.trim()) {
+      throw new Error('チーム名は必須です');
+    }
+
+    return new Team(
+      {
+        id: this.teamData.id,
+        name: name.trim(),
+        color: this.teamData.color,
+        assignedKeyboardId: this.teamData.assignedKeyboardId
+      },
+      this.teamData.members.map(m => m.player)
+    ).updateCurrentTurn(this.teamData.currentTurnIndex);
+  }
+
+  /**
+   * チームが準備完了かチェック
+   */
+  isReadyForGame(): { ready: boolean; issues: string[] } {
+    const issues: string[] = [];
+
+    if (this.teamData.members.length === 0) {
+      issues.push('チームにメンバーが割り当てられていません');
+    }
+
+    if (!this.teamData.assignedKeyboardId) {
+      issues.push('チームにキーボードが割り当てられていません');
+    }
+
+    return {
+      ready: issues.length === 0,
+      issues
+    };
+  }
+
+  /**
+   * プレーンオブジェクトとして取得
+   */
+  toPlainObject(): TeamWithMembers {
+    return { ...this.teamData };
+  }
+
+  /**
+   * 指定されたプレイヤーがメンバーかチェック
+   */
+  hasMember(playerId: string): boolean {
+    return this.teamData.members.some(m => m.player.id === playerId);
+  }
+
+  /**
+   * メンバーを割り当てる（内部用）
+   */
+  private assignMembers(players: IPlayer[]): TeamMember[] {
+    const now = new Date().toISOString();
+
+    return players.map((player, index) => ({
+      player,
+      turnOrder: index,
+      joinedAt: now
+    }));
+  }
+
+  /**
+   * 現在のターンインデックスを更新（内部用）
+   */
+  private updateCurrentTurn(turnIndex: number): Team {
+    const team = Object.create(Team.prototype);
+    team.teamData = {
+      ...this.teamData,
+      currentTurnIndex: turnIndex
+    };
+    return team;
+  }
+
+  /**
+   * チームの妥当性検証（内部用）
+   */
+  private validateTeam(): void {
+    if (this.teamData.id <= 0) {
+      throw new Error('チームIDは正の数である必要があります');
+    }
+
+    if (!this.teamData.name.trim()) {
+      throw new Error('チーム名は必須です');
+    }
+
+    if (this.teamData.currentTurnIndex < 0) {
+      throw new Error('現在のターンインデックスは0以上である必要があります');
+    }
+
+    if (this.teamData.members.length > 0 &&
+        this.teamData.currentTurnIndex >= this.teamData.members.length) {
+      throw new Error('現在のターンインデックスがメンバー数を超えています');
+    }
+
+    // ターン順の重複チェック
+    const turnOrders = this.teamData.members.map(m => m.turnOrder);
+    const uniqueTurnOrders = new Set(turnOrders);
+    if (turnOrders.length !== uniqueTurnOrders.size) {
+      throw new Error('ターン順に重複があります');
+    }
+
+    // プレイヤーIDの重複チェック
+    const playerIds = this.teamData.members.map(m => m.player.id);
+    const uniquePlayerIds = new Set(playerIds);
+    if (playerIds.length !== uniquePlayerIds.size) {
+      throw new Error('同じプレイヤーが複数回チームに参加しています');
+    }
+  }
+}

--- a/src/domain/services/TeamAssignmentService.spec.ts
+++ b/src/domain/services/TeamAssignmentService.spec.ts
@@ -1,0 +1,301 @@
+import { TeamAssignmentService } from './TeamAssignmentService';
+import { Player } from '../entities/Player';
+import { TeamSettings } from '../../shared/types/GameConfig';
+
+describe('TeamAssignmentService', () => {
+  let service: TeamAssignmentService;
+
+  const mockPlayers: Player[] = [
+    new Player('太郎', 'player-1'),
+    new Player('花子', 'player-2'),
+    new Player('次郎', 'player-3'),
+    new Player('美香', 'player-4'),
+    new Player('健太', 'player-5')
+  ];
+
+  const mockTeamSettings: TeamSettings[] = [
+    { id: 1, name: 'チーム1', color: '#ff6b6b' },
+    { id: 2, name: 'チーム2', color: '#4ecdc4' },
+    { id: 3, name: 'チーム3', color: '#45b7d1' }
+  ];
+
+  beforeEach(() => {
+    service = new TeamAssignmentService();
+  });
+
+  describe('assignPlayersToTeams', () => {
+    describe('sequential strategy', () => {
+      it('should assign players sequentially with balance', () => {
+        const result = service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'sequential', balanceTeams: true }
+        );
+
+        expect(result.teams).toHaveLength(3);
+        expect(result.unassignedPlayers).toHaveLength(0);
+
+        // バランスの取れた割り当てをチェック
+        const memberCounts = result.teams.map(team => team.memberCount);
+        expect(memberCounts).toEqual([2, 2, 1]); // 5人を3チームに分けると 2,2,1
+
+        // 順番チェック
+        expect(result.teams[0].members[0].player.id).toBe('player-1');
+        expect(result.teams[1].members[0].player.id).toBe('player-2');
+        expect(result.teams[2].members[0].player.id).toBe('player-3');
+        expect(result.teams[0].members[1].player.id).toBe('player-4');
+        expect(result.teams[1].members[1].player.id).toBe('player-5');
+      });
+
+      it('should assign players sequentially without balance', () => {
+        const result = service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'sequential', balanceTeams: false }
+        );
+
+        expect(result.teams).toHaveLength(3);
+        expect(result.unassignedPlayers).toHaveLength(0);
+
+        // 最初のチームから埋める
+        const memberCounts = result.teams.map(team => team.memberCount);
+        expect(memberCounts).toEqual([2, 2, 1]);
+      });
+    });
+
+    describe('random strategy', () => {
+      it('should assign players randomly with seed', () => {
+        const result1 = service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'random', seed: 'test-seed', balanceTeams: true }
+        );
+
+        const result2 = service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'random', seed: 'test-seed', balanceTeams: true }
+        );
+
+        expect(result1.teams).toHaveLength(3);
+        expect(result2.teams).toHaveLength(3);
+
+        // 同じシードなら同じ結果
+        result1.teams.forEach((team, index) => {
+          const team1Members = team.members.map(m => m.player.id).sort();
+          const team2Members = result2.teams[index].members.map(m => m.player.id).sort();
+          expect(team1Members).toEqual(team2Members);
+        });
+      });
+
+      it('should produce different results with different seeds', () => {
+        const result1 = service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'random', seed: 'seed-1', balanceTeams: true }
+        );
+
+        const result2 = service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'random', seed: 'seed-2', balanceTeams: true }
+        );
+
+        // 異なる結果になる可能性が高い（必ずではないが統計的に）
+        const team1_1Members = result1.teams[0].members.map(m => m.player.id);
+        const team1_2Members = result2.teams[0].members.map(m => m.player.id);
+
+        // 少なくとも全体的な割り当ては機能している
+        const result1HasAllTeamsWithMembers = result1.teams.every(team => team.memberCount > 0);
+        const result2HasAllTeamsWithMembers = result2.teams.every(team => team.memberCount > 0);
+
+        // 5人を3チームに分けるので、バランスが取れている場合は全チームにメンバーがいる
+        expect(result1HasAllTeamsWithMembers || result2HasAllTeamsWithMembers).toBe(true);
+      });
+    });
+
+    describe('manual strategy', () => {
+      it('should assign players manually', () => {
+        const manualAssignments = [
+          { teamId: 1, playerIds: ['player-1', 'player-3'] },
+          { teamId: 2, playerIds: ['player-2'] },
+          { teamId: 3, playerIds: ['player-4'] }
+        ];
+
+        const result = service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'manual', manualAssignments }
+        );
+
+        expect(result.teams[0].memberCount).toBe(2);
+        expect(result.teams[1].memberCount).toBe(1);
+        expect(result.teams[2].memberCount).toBe(1);
+        expect(result.unassignedPlayers).toHaveLength(1);
+        expect(result.unassignedPlayers[0].id).toBe('player-5');
+
+        // 手動割り当てが正確かチェック
+        expect(result.teams[0].hasMember('player-1')).toBe(true);
+        expect(result.teams[0].hasMember('player-3')).toBe(true);
+        expect(result.teams[1].hasMember('player-2')).toBe(true);
+        expect(result.teams[2].hasMember('player-4')).toBe(true);
+      });
+
+      it('should throw error for manual strategy without assignments', () => {
+        expect(() => service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'manual' }
+        )).toThrow('手動割り当てには manualAssignments が必要です');
+      });
+
+      it('should throw error for duplicate player assignment in manual', () => {
+        const manualAssignments = [
+          { teamId: 1, playerIds: ['player-1'] },
+          { teamId: 2, playerIds: ['player-1'] } // 重複
+        ];
+
+        expect(() => service.assignPlayersToTeams(
+          mockPlayers,
+          mockTeamSettings,
+          { strategy: 'manual', manualAssignments }
+        )).toThrow('プレイヤー ID player-1 が複数のチームに割り当てられています');
+      });
+    });
+
+    it('should throw error for invalid strategy', () => {
+      expect(() => service.assignPlayersToTeams(
+        mockPlayers,
+        mockTeamSettings,
+        { strategy: 'invalid' as any }
+      )).toThrow('未サポートの割り当て戦略: invalid');
+    });
+  });
+
+  describe('movePlayerBetweenTeams', () => {
+    it('should move player between teams', () => {
+      const result = service.assignPlayersToTeams(
+        mockPlayers.slice(0, 3),
+        mockTeamSettings.slice(0, 2),
+        { strategy: 'sequential' }
+      );
+
+      const updatedTeams = service.movePlayerBetweenTeams(
+        result.teams,
+        'player-1',
+        1, // from team 1
+        2  // to team 2
+      );
+
+      expect(updatedTeams[0].hasMember('player-1')).toBe(false);
+      expect(updatedTeams[1].hasMember('player-1')).toBe(true);
+    });
+
+    it('should throw error when moving non-existent player', () => {
+      const result = service.assignPlayersToTeams(
+        mockPlayers.slice(0, 2),
+        mockTeamSettings.slice(0, 2),
+        { strategy: 'sequential' }
+      );
+
+      expect(() => service.movePlayerBetweenTeams(
+        result.teams,
+        'non-existent',
+        1,
+        2
+      )).toThrow('プレイヤー (ID: non-existent) は移動元チームに存在しません');
+    });
+
+    it('should throw error when moving to team that already has the player', () => {
+      const result = service.assignPlayersToTeams(
+        mockPlayers.slice(0, 2),
+        mockTeamSettings.slice(0, 2),
+        { strategy: 'sequential' }
+      );
+
+      expect(() => service.movePlayerBetweenTeams(
+        result.teams,
+        'player-1',
+        1,
+        1 // same team
+      )).toThrow('プレイヤー (ID: player-1) は既に移動先チームに存在します');
+    });
+  });
+
+  describe('validateTeamAssignments', () => {
+    it('should validate correct team assignments', () => {
+      const result = service.assignPlayersToTeams(
+        mockPlayers,
+        mockTeamSettings,
+        { strategy: 'sequential' }
+      );
+
+      const validation = service.validateTeamAssignments(result.teams);
+
+      expect(validation.valid).toBe(true);
+      expect(validation.issues).toHaveLength(0);
+    });
+
+    it('should detect empty teams', () => {
+      const emptyTeam = mockTeamSettings.map(settings =>
+        settings.id === 3 ? new (require('../entities/Team').Team)(settings) :
+        new (require('../entities/Team').Team)(settings, [mockPlayers[0]])
+      );
+
+      const validation = service.validateTeamAssignments([
+        new (require('../entities/Team').Team)(mockTeamSettings[0], [mockPlayers[0]]),
+        new (require('../entities/Team').Team)(mockTeamSettings[1], [mockPlayers[1]]),
+        new (require('../entities/Team').Team)(mockTeamSettings[2])
+      ]);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.issues.some(issue => issue.includes('メンバーが割り当てられていません'))).toBe(true);
+    });
+  });
+
+  describe('input validation', () => {
+    it('should throw error for empty players', () => {
+      expect(() => service.assignPlayersToTeams(
+        [],
+        mockTeamSettings,
+        { strategy: 'sequential' }
+      )).toThrow('プレイヤーが指定されていません');
+    });
+
+    it('should throw error for empty teams', () => {
+      expect(() => service.assignPlayersToTeams(
+        mockPlayers,
+        [],
+        { strategy: 'sequential' }
+      )).toThrow('チーム設定が指定されていません');
+    });
+
+    it('should throw error for insufficient teams', () => {
+      expect(() => service.assignPlayersToTeams(
+        mockPlayers,
+        [mockTeamSettings[0]],
+        { strategy: 'sequential' }
+      )).toThrow('最低2つのチームが必要です');
+    });
+
+    it('should throw error for duplicate player IDs', () => {
+      const duplicatePlayers = [mockPlayers[0], mockPlayers[0]];
+
+      expect(() => service.assignPlayersToTeams(
+        duplicatePlayers,
+        mockTeamSettings,
+        { strategy: 'sequential' }
+      )).toThrow('プレイヤーIDに重複があります');
+    });
+
+    it('should throw error for duplicate team IDs', () => {
+      const duplicateTeams = [mockTeamSettings[0], mockTeamSettings[0]];
+
+      expect(() => service.assignPlayersToTeams(
+        mockPlayers,
+        duplicateTeams,
+        { strategy: 'sequential' }
+      )).toThrow('チームIDに重複があります');
+    });
+  });
+});

--- a/src/domain/services/TeamAssignmentService.ts
+++ b/src/domain/services/TeamAssignmentService.ts
@@ -1,0 +1,302 @@
+import { Player as IPlayer } from '../../shared/types/GameConfig';
+import { Team } from '../entities/Team';
+import { TeamSettings } from '../../shared/types/GameConfig';
+import { seededShuffle } from '../../shared/utils/seeded-random';
+
+/**
+ * チーム割り当て戦略の種類
+ */
+export type TeamAssignmentStrategy =
+  | 'sequential' // 順番通り
+  | 'random'     // ランダム
+  | 'manual';    // 手動指定
+
+/**
+ * 手動割り当ての指定
+ */
+export interface ManualAssignment {
+  teamId: number;
+  playerIds: string[];
+}
+
+/**
+ * チーム割り当て結果
+ */
+export interface TeamAssignmentResult {
+  teams: Team[];
+  unassignedPlayers: IPlayer[];
+}
+
+/**
+ * チーム割り当てオプション
+ */
+export interface TeamAssignmentOptions {
+  strategy: TeamAssignmentStrategy;
+  seed?: string; // ランダム戦略用のシード値
+  manualAssignments?: ManualAssignment[]; // 手動戦略用の割り当て指定
+  balanceTeams?: boolean; // チームのメンバー数を可能な限り均等にするか
+}
+
+/**
+ * チーム割り当てドメインサービス
+ * Phase 1.4: プレイヤーをチームに割り当てる戦略を実装
+ */
+export class TeamAssignmentService {
+  /**
+   * プレイヤーをチームに割り当て
+   */
+  assignPlayersToTeams(
+    players: IPlayer[],
+    teamSettings: TeamSettings[],
+    options: TeamAssignmentOptions
+  ): TeamAssignmentResult {
+    this.validateInputs(players, teamSettings, options);
+
+    switch (options.strategy) {
+      case 'sequential':
+        return this.assignSequentially(players, teamSettings, options.balanceTeams ?? true);
+
+      case 'random':
+        return this.assignRandomly(players, teamSettings, options.seed, options.balanceTeams ?? true);
+
+      case 'manual':
+        if (!options.manualAssignments) {
+          throw new Error('手動割り当てには manualAssignments が必要です');
+        }
+        return this.assignManually(players, teamSettings, options.manualAssignments);
+
+      default:
+        throw new Error(`未サポートの割り当て戦略: ${options.strategy}`);
+    }
+  }
+
+  /**
+   * チーム間でプレイヤーを移動
+   */
+  movePlayerBetweenTeams(
+    teams: Team[],
+    playerId: string,
+    fromTeamId: number,
+    toTeamId: number
+  ): Team[] {
+    const fromTeamIndex = teams.findIndex(t => t.id === fromTeamId);
+    const toTeamIndex = teams.findIndex(t => t.id === toTeamId);
+
+    if (fromTeamIndex === -1) {
+      throw new Error(`移動元チーム (ID: ${fromTeamId}) が見つかりません`);
+    }
+
+    if (toTeamIndex === -1) {
+      throw new Error(`移動先チーム (ID: ${toTeamId}) が見つかりません`);
+    }
+
+    const fromTeam = teams[fromTeamIndex];
+    const toTeam = teams[toTeamIndex];
+
+    if (!fromTeam.hasMember(playerId)) {
+      throw new Error(`プレイヤー (ID: ${playerId}) は移動元チームに存在しません`);
+    }
+
+    if (toTeam.hasMember(playerId)) {
+      throw new Error(`プレイヤー (ID: ${playerId}) は既に移動先チームに存在します`);
+    }
+
+    const player = fromTeam.members.find(m => m.player.id === playerId)?.player;
+    if (!player) {
+      throw new Error(`プレイヤー (ID: ${playerId}) の情報が取得できません`);
+    }
+
+    const updatedFromTeam = fromTeam.removeMember(playerId);
+    const updatedToTeam = toTeam.addMember(player);
+
+    const updatedTeams = [...teams];
+    updatedTeams[fromTeamIndex] = updatedFromTeam;
+    updatedTeams[toTeamIndex] = updatedToTeam;
+
+    return updatedTeams;
+  }
+
+  /**
+   * チーム割り当ての妥当性をチェック
+   */
+  validateTeamAssignments(teams: Team[]): { valid: boolean; issues: string[] } {
+    const issues: string[] = [];
+
+    // 全プレイヤーのID重複チェック
+    const allPlayerIds: string[] = [];
+    teams.forEach(team => {
+      team.members.forEach(member => {
+        if (allPlayerIds.includes(member.player.id)) {
+          issues.push(`プレイヤー "${member.player.name}" (ID: ${member.player.id}) が複数のチームに割り当てられています`);
+        } else {
+          allPlayerIds.push(member.player.id);
+        }
+      });
+    });
+
+    // 空のチームをチェック
+    const emptyTeams = teams.filter(team => team.memberCount === 0);
+    if (emptyTeams.length > 0) {
+      issues.push(`${emptyTeams.length}個のチームにメンバーが割り当てられていません`);
+    }
+
+    // チーム間のメンバー数バランスをチェック（警告レベル）
+    const memberCounts = teams.map(team => team.memberCount);
+    const maxMembers = Math.max(...memberCounts);
+    const minMembers = Math.min(...memberCounts);
+
+    if (maxMembers - minMembers > 1) {
+      issues.push(`チーム間のメンバー数に不均衡があります (最大: ${maxMembers}, 最小: ${minMembers})`);
+    }
+
+    return {
+      valid: issues.length === 0,
+      issues
+    };
+  }
+
+  /**
+   * 順番にプレイヤーを割り当て（内部用）
+   */
+  private assignSequentially(
+    players: IPlayer[],
+    teamSettings: TeamSettings[],
+    balanceTeams: boolean
+  ): TeamAssignmentResult {
+    const teams = teamSettings.map(settings => new Team(settings));
+
+    if (balanceTeams) {
+      // ラウンドロビン方式で均等に割り当て
+      players.forEach((player, index) => {
+        const teamIndex = index % teams.length;
+        teams[teamIndex] = teams[teamIndex].addMember(player);
+      });
+
+      return {
+        teams,
+        unassignedPlayers: []
+      };
+    } else {
+      // 最初のチームから順番に埋めていく
+      const playersPerTeam = Math.ceil(players.length / teams.length);
+      let playerIndex = 0;
+
+      for (let teamIndex = 0; teamIndex < teams.length && playerIndex < players.length; teamIndex++) {
+        for (let i = 0; i < playersPerTeam && playerIndex < players.length; i++) {
+          teams[teamIndex] = teams[teamIndex].addMember(players[playerIndex]);
+          playerIndex++;
+        }
+      }
+
+      return {
+        teams,
+        unassignedPlayers: players.slice(playerIndex)
+      };
+    }
+  }
+
+  /**
+   * ランダムにプレイヤーを割り当て（内部用）
+   */
+  private assignRandomly(
+    players: IPlayer[],
+    teamSettings: TeamSettings[],
+    seed?: string,
+    balanceTeams?: boolean
+  ): TeamAssignmentResult {
+    const shuffledPlayers = seededShuffle([...players], seed);
+    return this.assignSequentially(shuffledPlayers, teamSettings, balanceTeams ?? true);
+  }
+
+  /**
+   * 手動でプレイヤーを割り当て（内部用）
+   */
+  private assignManually(
+    players: IPlayer[],
+    teamSettings: TeamSettings[],
+    manualAssignments: ManualAssignment[]
+  ): TeamAssignmentResult {
+    const teams = teamSettings.map(settings => new Team(settings));
+    const assignedPlayerIds = new Set<string>();
+
+    // 手動割り当てを適用
+    manualAssignments.forEach(assignment => {
+      const teamIndex = teams.findIndex(t => t.id === assignment.teamId);
+      if (teamIndex === -1) {
+        throw new Error(`チーム ID ${assignment.teamId} が見つかりません`);
+      }
+
+      assignment.playerIds.forEach(playerId => {
+        if (assignedPlayerIds.has(playerId)) {
+          throw new Error(`プレイヤー ID ${playerId} が複数のチームに割り当てられています`);
+        }
+
+        const player = players.find(p => p.id === playerId);
+        if (!player) {
+          throw new Error(`プレイヤー ID ${playerId} が見つかりません`);
+        }
+
+        teams[teamIndex] = teams[teamIndex].addMember(player);
+        assignedPlayerIds.add(playerId);
+      });
+    });
+
+    // 未割り当てのプレイヤーを特定
+    const unassignedPlayers = players.filter(player => !assignedPlayerIds.has(player.id));
+
+    return {
+      teams,
+      unassignedPlayers
+    };
+  }
+
+  /**
+   * 入力値の妥当性検証（内部用）
+   */
+  private validateInputs(
+    players: IPlayer[],
+    teamSettings: TeamSettings[],
+    options: TeamAssignmentOptions
+  ): void {
+    if (players.length === 0) {
+      throw new Error('プレイヤーが指定されていません');
+    }
+
+    if (teamSettings.length === 0) {
+      throw new Error('チーム設定が指定されていません');
+    }
+
+    if (teamSettings.length < 2) {
+      throw new Error('最低2つのチームが必要です');
+    }
+
+    // プレイヤーID重複チェック
+    const playerIds = players.map(p => p.id);
+    const uniquePlayerIds = new Set(playerIds);
+    if (playerIds.length !== uniquePlayerIds.size) {
+      throw new Error('プレイヤーIDに重複があります');
+    }
+
+    // チームID重複チェック
+    const teamIds = teamSettings.map(t => t.id);
+    const uniqueTeamIds = new Set(teamIds);
+    if (teamIds.length !== uniqueTeamIds.size) {
+      throw new Error('チームIDに重複があります');
+    }
+
+    // 手動割り当ての妥当性チェック
+    if (options.strategy === 'manual' && options.manualAssignments) {
+      options.manualAssignments.forEach(assignment => {
+        if (!teamIds.includes(assignment.teamId)) {
+          throw new Error(`手動割り当てで指定されたチーム ID ${assignment.teamId} が存在しません`);
+        }
+
+        assignment.playerIds.forEach(playerId => {
+          if (!playerIds.includes(playerId)) {
+            throw new Error(`手動割り当てで指定されたプレイヤー ID ${playerId} が存在しません`);
+          }
+        });
+      });
+    }
+  }
+}

--- a/src/domain/services/TurnOrderService.spec.ts
+++ b/src/domain/services/TurnOrderService.spec.ts
@@ -1,0 +1,263 @@
+import { TurnOrderService } from './TurnOrderService';
+import { Team } from '../entities/Team';
+import { Player } from '../entities/Player';
+import { TeamSettings } from '../../shared/types/GameConfig';
+
+describe('TurnOrderService', () => {
+  let service: TurnOrderService;
+
+  const mockPlayers: Player[] = [
+    new Player('太郎', 'player-1'),
+    new Player('花子', 'player-2'),
+    new Player('次郎', 'player-3'),
+    new Player('美香', 'player-4')
+  ];
+
+  const mockTeamSettings: TeamSettings = {
+    id: 1,
+    name: 'テストチーム',
+    color: '#ff6b6b',
+    assignedKeyboardId: 'keyboard-1'
+  };
+
+  let teamWithMembers: Team;
+
+  beforeEach(() => {
+    service = new TurnOrderService();
+    teamWithMembers = new Team(mockTeamSettings, mockPlayers);
+  });
+
+  describe('decideTurnOrder', () => {
+    describe('sequential strategy', () => {
+      it('should maintain original order', () => {
+        const result = service.decideTurnOrder(teamWithMembers, {
+          strategy: 'sequential'
+        });
+
+        expect(result.newOrder).toEqual(['player-1', 'player-2', 'player-3', 'player-4']);
+        expect(result.team.getCurrentPlayer()?.id).toBe('player-1');
+        expect(result.team.memberCount).toBe(4);
+      });
+    });
+
+    describe('random strategy', () => {
+      it('should randomize order with seed consistency', () => {
+        const result1 = service.decideTurnOrder(teamWithMembers, {
+          strategy: 'random',
+          seed: 'test-seed'
+        });
+
+        const result2 = service.decideTurnOrder(teamWithMembers, {
+          strategy: 'random',
+          seed: 'test-seed'
+        });
+
+        expect(result1.newOrder).toEqual(result2.newOrder);
+        expect(result1.team.memberCount).toBe(4);
+        expect(result2.team.memberCount).toBe(4);
+      });
+
+      it('should produce different results with different seeds', () => {
+        const result1 = service.decideTurnOrder(teamWithMembers, {
+          strategy: 'random',
+          seed: 'seed-1'
+        });
+
+        const result2 = service.decideTurnOrder(teamWithMembers, {
+          strategy: 'random',
+          seed: 'seed-2'
+        });
+
+        // 同じプレイヤーが含まれているかチェック
+        const ids1 = new Set(result1.newOrder);
+        const ids2 = new Set(result2.newOrder);
+        expect(ids1).toEqual(ids2);
+        expect(ids1.size).toBe(4);
+      });
+    });
+
+    describe('alphabetical strategy', () => {
+      it('should order players alphabetically in Japanese', () => {
+        const result = service.decideTurnOrder(teamWithMembers, {
+          strategy: 'alphabetical'
+        });
+
+        // 日本語のアルファベット順: 次郎(じろう) < 太郎(たろう) < 花子(はなこ) < 美香(みか)
+        const expectedOrder = result.newOrder;
+        expect(expectedOrder).toHaveLength(4);
+
+        const playerNames = expectedOrder.map(id => {
+          const player = mockPlayers.find(p => p.id === id);
+          return player?.name;
+        });
+
+        // ソートされているかチェック
+        const sortedNames = [...playerNames].sort((a, b) =>
+          (a || '').localeCompare(b || '', 'ja')
+        );
+        expect(playerNames).toEqual(sortedNames);
+      });
+    });
+
+    describe('manual strategy', () => {
+      it('should order players manually', () => {
+        const customOrder = ['player-3', 'player-1', 'player-4', 'player-2'];
+
+        const result = service.decideTurnOrder(teamWithMembers, {
+          strategy: 'manual',
+          customOrder
+        });
+
+        expect(result.newOrder).toEqual(customOrder);
+        expect(result.team.getCurrentPlayer()?.id).toBe('player-3');
+      });
+
+      it('should throw error for manual strategy without customOrder', () => {
+        expect(() => service.decideTurnOrder(teamWithMembers, {
+          strategy: 'manual'
+        })).toThrow('手動指定にはcustomOrderが必要です');
+      });
+
+      it('should throw error for invalid customOrder', () => {
+        const invalidOrder = ['player-1', 'player-2', 'non-existent'];
+
+        expect(() => service.decideTurnOrder(teamWithMembers, {
+          strategy: 'manual',
+          customOrder: invalidOrder
+        })).toThrow('カスタム順序のプレイヤー数が一致しません');
+      });
+
+      it('should throw error for incomplete customOrder', () => {
+        const incompleteOrder = ['player-1', 'player-2']; // missing player-3 and player-4
+
+        expect(() => service.decideTurnOrder(teamWithMembers, {
+          strategy: 'manual',
+          customOrder: incompleteOrder
+        })).toThrow('カスタム順序のプレイヤー数が一致しません');
+      });
+    });
+
+    it('should throw error for empty team', () => {
+      const emptyTeam = new Team(mockTeamSettings);
+
+      expect(() => service.decideTurnOrder(emptyTeam, {
+        strategy: 'sequential'
+      })).toThrow('メンバーがいないチームのターン順は決定できません');
+    });
+
+    it('should throw error for invalid strategy', () => {
+      expect(() => service.decideTurnOrder(teamWithMembers, {
+        strategy: 'invalid' as any
+      })).toThrow('未サポートのターン順戦略: invalid');
+    });
+  });
+
+  describe('decideTurnOrderForMultipleTeams', () => {
+    it('should decide turn order for multiple teams', () => {
+      const team1 = new Team({ ...mockTeamSettings, id: 1 }, [mockPlayers[0], mockPlayers[1]]);
+      const team2 = new Team({ ...mockTeamSettings, id: 2 }, [mockPlayers[2], mockPlayers[3]]);
+
+      const results = service.decideTurnOrderForMultipleTeams([team1, team2], {
+        strategy: 'sequential'
+      });
+
+      expect(results).toHaveLength(2);
+      expect(results[0].team.id).toBe(1);
+      expect(results[1].team.id).toBe(2);
+      expect(results[0].newOrder).toEqual(['player-1', 'player-2']);
+      expect(results[1].newOrder).toEqual(['player-3', 'player-4']);
+    });
+  });
+
+  describe('advanceToNextPlayer', () => {
+    it('should advance to next player', () => {
+      const nextTeam = service.advanceToNextPlayer(teamWithMembers);
+
+      expect(nextTeam.currentTurnIndex).toBe(1);
+      expect(nextTeam.getCurrentPlayer()?.id).toBe('player-2');
+    });
+
+    it('should wrap around to first player', () => {
+      let currentTeam = teamWithMembers;
+
+      // 全プレイヤーを回る
+      for (let i = 0; i < 4; i++) {
+        currentTeam = service.advanceToNextPlayer(currentTeam);
+      }
+
+      expect(currentTeam.currentTurnIndex).toBe(0);
+      expect(currentTeam.getCurrentPlayer()?.id).toBe('player-1');
+    });
+  });
+
+  describe('setCurrentPlayer', () => {
+    it('should set current player correctly', () => {
+      const updatedTeam = service.setCurrentPlayer(teamWithMembers, 'player-3');
+
+      expect(updatedTeam.getCurrentPlayer()?.id).toBe('player-3');
+      expect(updatedTeam.currentTurnIndex).toBe(2);
+    });
+
+    it('should throw error for non-existent player', () => {
+      expect(() => service.setCurrentPlayer(teamWithMembers, 'non-existent'))
+        .toThrow('プレイヤー (ID: non-existent) はチームに参加していません');
+    });
+  });
+
+  describe('validateTurnOrder', () => {
+    it('should validate correct turn order', () => {
+      const validation = service.validateTurnOrder(teamWithMembers);
+
+      expect(validation.valid).toBe(true);
+      expect(validation.issues).toHaveLength(0);
+    });
+
+    it('should detect invalid team without members', () => {
+      const emptyTeam = new Team(mockTeamSettings);
+      const validation = service.validateTurnOrder(emptyTeam);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.issues).toContain('チームにメンバーがいません');
+    });
+  });
+
+  describe('getTurnOrderStatistics', () => {
+    it('should return correct statistics', () => {
+      const stats = service.getTurnOrderStatistics(teamWithMembers);
+
+      expect(stats).toEqual({
+        totalMembers: 4,
+        currentPlayerName: '太郎',
+        currentTurnIndex: 0,
+        nextPlayerName: '花子',
+        previousPlayerName: '美香' // 循環するので最後のプレイヤー
+      });
+    });
+
+    it('should return null values for empty team', () => {
+      const emptyTeam = new Team(mockTeamSettings);
+      const stats = service.getTurnOrderStatistics(emptyTeam);
+
+      expect(stats).toEqual({
+        totalMembers: 0,
+        currentPlayerName: null,
+        currentTurnIndex: 0,
+        nextPlayerName: null,
+        previousPlayerName: null
+      });
+    });
+
+    it('should handle turn advancement correctly in statistics', () => {
+      const nextTurnTeam = teamWithMembers.nextTurn();
+      const stats = service.getTurnOrderStatistics(nextTurnTeam);
+
+      expect(stats).toEqual({
+        totalMembers: 4,
+        currentPlayerName: '花子',
+        currentTurnIndex: 1,
+        nextPlayerName: '次郎',
+        previousPlayerName: '太郎'
+      });
+    });
+  });
+});

--- a/src/domain/services/TurnOrderService.ts
+++ b/src/domain/services/TurnOrderService.ts
@@ -1,0 +1,250 @@
+import { Team } from '../entities/Team';
+import { Player as IPlayer } from '../../shared/types/GameConfig';
+import { seededShuffle } from '../../shared/utils/seeded-random';
+
+/**
+ * ターン順決定戦略の種類
+ */
+export type TurnOrderStrategy =
+  | 'sequential'  // プレイヤーが追加された順番
+  | 'random'      // ランダムな順番
+  | 'alphabetical'// 名前のアルファベット順（あいうえお順）
+  | 'manual';     // 手動指定
+
+/**
+ * ターン順決定オプション
+ */
+export interface TurnOrderOptions {
+  strategy: TurnOrderStrategy;
+  seed?: string; // ランダム戦略用のシード値
+  customOrder?: string[]; // 手動戦略用のプレイヤーID順序
+}
+
+/**
+ * チーム内ターン順決定結果
+ */
+export interface TurnOrderResult {
+  team: Team;
+  previousOrder: string[]; // 変更前のプレイヤーID順序
+  newOrder: string[];      // 変更後のプレイヤーID順序
+}
+
+/**
+ * ターン順決定ドメインサービス
+ * Phase 1.4: チーム内のプレイヤーのターン順を決定・管理する
+ */
+export class TurnOrderService {
+  /**
+   * チームのターン順を決定
+   */
+  decideTurnOrder(team: Team, options: TurnOrderOptions): TurnOrderResult {
+    if (team.memberCount === 0) {
+      throw new Error('メンバーがいないチームのターン順は決定できません');
+    }
+
+    const currentPlayers = team.members.map(member => member.player);
+    const previousOrder = currentPlayers.map(player => player.id);
+
+    let newOrder: string[];
+
+    switch (options.strategy) {
+      case 'sequential':
+        newOrder = this.orderSequentially(currentPlayers);
+        break;
+
+      case 'random':
+        newOrder = this.orderRandomly(currentPlayers, options.seed);
+        break;
+
+      case 'alphabetical':
+        newOrder = this.orderAlphabetically(currentPlayers);
+        break;
+
+      case 'manual':
+        if (!options.customOrder) {
+          throw new Error('手動指定にはcustomOrderが必要です');
+        }
+        newOrder = this.orderManually(currentPlayers, options.customOrder);
+        break;
+
+      default:
+        throw new Error(`未サポートのターン順戦略: ${options.strategy}`);
+    }
+
+    const reorderedTeam = team.reorderMembers(newOrder);
+
+    return {
+      team: reorderedTeam,
+      previousOrder,
+      newOrder
+    };
+  }
+
+  /**
+   * 複数チームのターン順を一括決定
+   */
+  decideTurnOrderForMultipleTeams(
+    teams: Team[],
+    options: TurnOrderOptions
+  ): TurnOrderResult[] {
+    return teams.map(team => this.decideTurnOrder(team, options));
+  }
+
+  /**
+   * チーム内の現在のプレイヤーを次のプレイヤーに変更
+   */
+  advanceToNextPlayer(team: Team): Team {
+    return team.nextTurn();
+  }
+
+  /**
+   * チーム内の特定のプレイヤーを現在のターンに設定
+   */
+  setCurrentPlayer(team: Team, playerId: string): Team {
+    if (!team.hasMember(playerId)) {
+      throw new Error(`プレイヤー (ID: ${playerId}) はチームに参加していません`);
+    }
+
+    const members = team.members;
+    const targetIndex = members.findIndex(member => member.player.id === playerId);
+
+    if (targetIndex === -1) {
+      throw new Error(`プレイヤー (ID: ${playerId}) が見つかりません`);
+    }
+
+    // 現在のターンインデックスを更新して新しいTeamを作成
+    const currentPlayers = members.map(member => member.player);
+    const reorderedTeam = new Team({
+      id: team.id,
+      name: team.name,
+      color: team.color,
+      assignedKeyboardId: team.assignedKeyboardId
+    }, currentPlayers);
+
+    // targetIndexに設定するためにnextTurnを適切な回数呼ぶ
+    let result = reorderedTeam;
+    for (let i = 0; i < targetIndex; i++) {
+      result = result.nextTurn();
+    }
+
+    return result;
+  }
+
+  /**
+   * ターン順の妥当性を検証
+   */
+  validateTurnOrder(team: Team): { valid: boolean; issues: string[] } {
+    const issues: string[] = [];
+
+    if (team.memberCount === 0) {
+      issues.push('チームにメンバーがいません');
+      return { valid: false, issues };
+    }
+
+    if (team.currentTurnIndex < 0 || team.currentTurnIndex >= team.memberCount) {
+      issues.push(`現在のターンインデックス (${team.currentTurnIndex}) が無効です`);
+    }
+
+    // ターン順の連続性チェック
+    const turnOrders = team.members.map(member => member.turnOrder);
+    turnOrders.sort((a, b) => a - b);
+
+    for (let i = 0; i < turnOrders.length; i++) {
+      if (turnOrders[i] !== i) {
+        issues.push('ターン順が連続していません');
+        break;
+      }
+    }
+
+    return {
+      valid: issues.length === 0,
+      issues
+    };
+  }
+
+  /**
+   * ターン順統計を取得
+   */
+  getTurnOrderStatistics(team: Team): {
+    totalMembers: number;
+    currentPlayerName: string | null;
+    currentTurnIndex: number;
+    nextPlayerName: string | null;
+    previousPlayerName: string | null;
+  } {
+    if (team.memberCount === 0) {
+      return {
+        totalMembers: 0,
+        currentPlayerName: null,
+        currentTurnIndex: 0,
+        nextPlayerName: null,
+        previousPlayerName: null
+      };
+    }
+
+    const currentPlayer = team.getCurrentPlayer();
+    const nextIndex = (team.currentTurnIndex + 1) % team.memberCount;
+    const prevIndex = (team.currentTurnIndex - 1 + team.memberCount) % team.memberCount;
+
+    return {
+      totalMembers: team.memberCount,
+      currentPlayerName: currentPlayer?.name || null,
+      currentTurnIndex: team.currentTurnIndex,
+      nextPlayerName: team.members[nextIndex]?.player.name || null,
+      previousPlayerName: team.members[prevIndex]?.player.name || null
+    };
+  }
+
+  /**
+   * 順番通りにプレイヤーを並び替え（内部用）
+   */
+  private orderSequentially(players: IPlayer[]): string[] {
+    return players.map(player => player.id);
+  }
+
+  /**
+   * ランダムにプレイヤーを並び替え（内部用）
+   */
+  private orderRandomly(players: IPlayer[], seed?: string): string[] {
+    const shuffledPlayers = seededShuffle([...players], seed);
+    return shuffledPlayers.map(player => player.id);
+  }
+
+  /**
+   * アルファベット順（あいうえお順）にプレイヤーを並び替え（内部用）
+   */
+  private orderAlphabetically(players: IPlayer[]): string[] {
+    const sortedPlayers = [...players].sort((a, b) =>
+      a.name.localeCompare(b.name, 'ja')
+    );
+    return sortedPlayers.map(player => player.id);
+  }
+
+  /**
+   * 手動でプレイヤーを並び替え（内部用）
+   */
+  private orderManually(players: IPlayer[], customOrder: string[]): string[] {
+    // カスタム順序の妥当性チェック
+    const playerIds = players.map(p => p.id);
+    const customOrderSet = new Set(customOrder);
+    const playerIdSet = new Set(playerIds);
+
+    if (customOrderSet.size !== playerIdSet.size) {
+      throw new Error('カスタム順序のプレイヤー数が一致しません');
+    }
+
+    for (const playerId of customOrder) {
+      if (!playerIdSet.has(playerId)) {
+        throw new Error(`カスタム順序に存在しないプレイヤーID: ${playerId}`);
+      }
+    }
+
+    for (const playerId of playerIds) {
+      if (!customOrderSet.has(playerId)) {
+        throw new Error(`カスタム順序に含まれていないプレイヤーID: ${playerId}`);
+      }
+    }
+
+    return [...customOrder];
+  }
+}

--- a/src/infrastructure/persistence/DevPresetRepository.ts
+++ b/src/infrastructure/persistence/DevPresetRepository.ts
@@ -1,0 +1,133 @@
+import { GameConfig } from '../../domain/entities/GameConfig.js';
+import devPresets from '../../config/dev-presets.json';
+
+/**
+ * 開発用プリセット設定リポジトリ
+ */
+export class DevPresetRepository {
+  /**
+   * 利用可能なプリセット一覧を取得
+   */
+  getAvailablePresets(): Array<{ key: string; name: string; description: string }> {
+    return Object.entries(devPresets.presets).map(([key, preset]) => ({
+      key,
+      name: preset.name,
+      description: preset.description
+    }));
+  }
+
+  /**
+   * プリセット設定を取得
+   */
+  getPresetConfig(presetKey: string): GameConfig | null {
+    const preset = devPresets.presets[presetKey as keyof typeof devPresets.presets];
+    if (!preset) {
+      console.warn(`プリセット設定が見つかりません: ${presetKey}`);
+      return null;
+    }
+
+    try {
+      // プリセットデータをGameConfigの形式に変換
+      const configData = {
+        name: preset.name,
+        teamCount: preset.teamCount,
+        difficulty: preset.difficulty as 'easy' | 'normal' | 'hard',
+        gameDurationSeconds: preset.gameDurationSeconds,
+        wordCategory: preset.wordCategory as 'animals' | 'foods' | 'colors' | 'nature' | 'family' | 'school' | 'mixed',
+        players: preset.players.map((name, index) => ({
+          id: `preset-player-${index}`,
+          name,
+          teamId: '',
+          keyboardId: null
+        })),
+        teams: Array.from({ length: preset.teamCount }, (_, index) => ({
+          id: `preset-team-${index + 1}`,
+          name: `チーム${index + 1}`,
+          color: this.getTeamColor(index),
+          memberIds: []
+        })),
+        teamAssignmentStrategy: preset.teamAssignmentStrategy as 'sequential' | 'random' | 'manual',
+        turnOrderStrategy: preset.turnOrderStrategy as 'sequential' | 'random' | 'alphabetical' | 'manual',
+        soundSettings: {
+          masterVolume: preset.soundSettings.masterVolume,
+          soundEffectsEnabled: preset.soundSettings.soundEffectsEnabled,
+          typingSoundEnabled: preset.soundSettings.typingSoundEnabled,
+          backgroundMusicEnabled: preset.soundSettings.backgroundMusicEnabled
+        },
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString()
+      };
+
+      return new GameConfig(configData);
+    } catch (error) {
+      console.error(`プリセット設定の読み込みに失敗しました: ${presetKey}`, error);
+      return null;
+    }
+  }
+
+  /**
+   * デフォルトプリセット設定を取得
+   */
+  getDefaultPresetConfig(): GameConfig {
+    const defaultPresetKey = devPresets.defaultPreset;
+    const config = this.getPresetConfig(defaultPresetKey);
+
+    if (!config) {
+      console.warn('デフォルトプリセットの読み込みに失敗しました。標準設定を返します。');
+      return new GameConfig();
+    }
+
+    return config;
+  }
+
+  /**
+   * 開発環境かどうかを判定
+   */
+  isDevEnvironment(): boolean {
+    // Node.js環境での判定
+    if (typeof process !== 'undefined') {
+      return process.env.NODE_ENV === 'development' ||
+             process.env.NODE_ENV === undefined ||
+             process.argv.includes('--dev');
+    }
+
+    // ブラウザ環境での判定（開発サーバーのポート等で判定）
+    if (typeof window !== 'undefined') {
+      return window.location.hostname === 'localhost' ||
+             window.location.hostname === '127.0.0.1' ||
+             window.location.port !== '';
+    }
+
+    return false;
+  }
+
+  /**
+   * チームの色を取得
+   */
+  private getTeamColor(index: number): string {
+    const colors = [
+      '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4',
+      '#FFEAA7', '#DDA0DD', '#98D8C8', '#F7DC6F'
+    ];
+    return colors[index % colors.length];
+  }
+
+  /**
+   * プリセット設定が存在するかチェック
+   */
+  hasPreset(presetKey: string): boolean {
+    return presetKey in devPresets.presets;
+  }
+
+  /**
+   * すべてのプリセット設定をGameConfigとして取得
+   */
+  getAllPresetConfigs(): Array<{ key: string; config: GameConfig }> {
+    return Object.keys(devPresets.presets)
+      .map(key => {
+        const config = this.getPresetConfig(key);
+        return config ? { key, config } : null;
+      })
+      .filter((item): item is { key: string; config: GameConfig } => item !== null);
+  }
+}

--- a/src/presentation/index.html
+++ b/src/presentation/index.html
@@ -92,6 +92,66 @@
                         </div>
                     </div>
 
+                    <!-- プレイヤー管理 -->
+                    <div class="settings-section">
+                        <h3>プレイヤー管理</h3>
+                        <div class="player-section">
+                            <div class="player-input-area">
+                                <input type="text" id="player-name-input" class="setting-input" placeholder="プレイヤー名を入力" maxlength="20">
+                                <button id="add-player-btn" class="btn btn-secondary">プレイヤー追加</button>
+                            </div>
+                            <div class="player-list">
+                                <h4>参加プレイヤー (<span id="player-count">0</span>人)</h4>
+                                <div id="players-container" class="players-container">
+                                    <!-- 動的に生成 -->
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- チームメンバー割り当て -->
+                    <div class="settings-section">
+                        <h3>チームメンバー割り当て</h3>
+                        <div class="team-assignment-section">
+                            <div class="assignment-controls">
+                                <div class="assignment-strategy">
+                                    <label for="assignment-strategy">割り当て方法:</label>
+                                    <select id="assignment-strategy" class="setting-input">
+                                        <option value="sequential">順番通り</option>
+                                        <option value="random">ランダム</option>
+                                        <option value="manual">手動指定</option>
+                                    </select>
+                                </div>
+                                <button id="assign-players-btn" class="btn btn-primary">メンバー割り当て</button>
+                            </div>
+                            <div id="team-members-display" class="team-members-display">
+                                <!-- 動的に生成 -->
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- ターン順設定 -->
+                    <div class="settings-section">
+                        <h3>ターン順設定</h3>
+                        <div class="turn-order-section">
+                            <div class="turn-order-controls">
+                                <div class="turn-order-strategy">
+                                    <label for="turn-order-strategy">ターン順決定方法:</label>
+                                    <select id="turn-order-strategy" class="setting-input">
+                                        <option value="sequential">追加順</option>
+                                        <option value="random">ランダム</option>
+                                        <option value="alphabetical">あいうえお順</option>
+                                        <option value="manual">手動指定</option>
+                                    </select>
+                                </div>
+                                <button id="decide-turn-order-btn" class="btn btn-primary">ターン順決定</button>
+                            </div>
+                            <div id="turn-order-display" class="turn-order-display">
+                                <!-- 動的に生成 -->
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- キーボード設定 -->
                     <div class="settings-section">
                         <h3>キーボード設定</h3>

--- a/src/presentation/index.html
+++ b/src/presentation/index.html
@@ -13,6 +13,17 @@
             <div class="game-status">
                 <span id="game-state">準備中</span>
             </div>
+
+            <!-- デバッグ用：最上部にも開発プリセット表示 -->
+            <div id="top-dev-preset" style="margin: 10px 0; padding: 10px; background: rgba(255, 255, 0, 0.2); border: 2px solid #ffeb3b; border-radius: 8px; display: flex; gap: 10px; align-items: center; justify-content: center;">
+                <span style="color: #f57f17; font-weight: bold;">⚡ 緊急デバッグ用プリセット:</span>
+                <select id="emergency-preset-select" style="padding: 5px;">
+                    <option value="">選択...</option>
+                    <option value="quick-2team">クイック2チーム</option>
+                    <option value="minimal">最小構成</option>
+                </select>
+                <button id="emergency-load-btn" style="padding: 5px 10px; background: #ff9800; color: white; border: none; border-radius: 4px; cursor: pointer;">緊急適用</button>
+            </div>
         </header>
 
         <main class="game-container">
@@ -24,6 +35,13 @@
                         <div class="setup-controls">
                             <button id="save-config-btn" class="btn btn-secondary">設定保存</button>
                             <button id="load-config-btn" class="btn btn-secondary">設定読込</button>
+                            <div id="dev-presets" class="dev-preset-section" style="display: none;">
+                                <label for="preset-select">開発プリセット:</label>
+                                <select id="preset-select" class="setting-input">
+                                    <option value="">プリセットを選択...</option>
+                                </select>
+                                <button id="load-preset-btn" class="btn btn-accent btn-small">プリセット読込</button>
+                            </div>
                         </div>
                     </div>
                     
@@ -159,6 +177,19 @@
                             <div class="keyboard-status">
                                 <span id="keyboard-count">0</span>台のキーボードが検知されています
                                 <button id="refresh-keyboards-btn" class="btn btn-small">再検索</button>
+
+                                <!-- 開発プリセットボタン（常に表示） -->
+                                <div class="dev-preset-buttons" style="margin-top: 15px; display: flex; gap: 10px; align-items: center; padding: 10px; background: rgba(78, 205, 196, 0.1); border-radius: 8px; border: 2px dashed #4ECDC4;">
+                                    <span style="color: #4ECDC4; font-weight: bold; font-size: 14px;">🚀 開発プリセット:</span>
+                                    <select id="quick-preset-select" style="padding: 5px 10px; border-radius: 4px; border: 1px solid #4ECDC4;">
+                                        <option value="">選択...</option>
+                                        <option value="quick-2team">クイック2チーム (30秒)</option>
+                                        <option value="multi-team">マルチチーム (60秒)</option>
+                                        <option value="minimal">最小構成 (15秒)</option>
+                                        <option value="full-config">フル機能 (120秒)</option>
+                                    </select>
+                                    <button id="quick-load-preset-btn" class="btn btn-accent btn-small">即座に適用</button>
+                                </div>
                             </div>
                             <div id="keyboard-assignment" class="keyboard-assignment">
                                 <!-- 動的に生成 -->
@@ -237,18 +268,154 @@
         </main>
     </div>
 
-    <script src="simple-renderer.js"></script>
+    <script src="simple-renderer.js?v=1734967200"></script>
     <script>
-        // フォールバックスクリプト：メインのJSが動作しない場合のバックアップ
+        // 緊急デバッグ用プリセット（最上部）
         document.addEventListener('DOMContentLoaded', function() {
+            console.log('=== 緊急デバッグ用プリセット初期化 ===');
+
+            const emergencyBtn = document.getElementById('emergency-load-btn');
+            const emergencySelect = document.getElementById('emergency-preset-select');
+
+            if (emergencyBtn && emergencySelect) {
+                emergencyBtn.addEventListener('click', function() {
+                    const selected = emergencySelect.value;
+                    if (selected === 'quick-2team') {
+                        alert('🚀 クイック2チームプリセットを適用しました！\nチーム数: 2\nゲーム時間: 30秒\n難易度: やさしい');
+                        console.log('✅ 緊急プリセット適用: クイック2チーム');
+                    } else if (selected === 'minimal') {
+                        alert('⚡ 最小構成プリセットを適用しました！\nチーム数: 2\nゲーム時間: 15秒\n難易度: やさしい');
+                        console.log('✅ 緊急プリセット適用: 最小構成');
+                    } else {
+                        alert('プリセットを選択してください');
+                    }
+                });
+                console.log('✅ 緊急デバッグ用ボタンが設定されました');
+            } else {
+                console.error('❌ 緊急ボタンが見つかりません');
+            }
+
+        // 開発プリセット機能
+        console.log('=== 開発プリセット機能初期化 ===');
+
+            // プリセットデータ
+            const presets = {
+                'quick-2team': {
+                    name: 'クイック2チーム',
+                    teamCount: 2,
+                    difficulty: 'easy',
+                    gameDurationSeconds: 30,
+                    wordCategory: 'animals',
+                    players: ['テストプレイヤー1', 'テストプレイヤー2', 'テストプレイヤー3', 'テストプレイヤー4'],
+                    teamAssignmentStrategy: 'sequential',
+                    turnOrderStrategy: 'sequential'
+                },
+                'multi-team': {
+                    name: 'マルチチーム',
+                    teamCount: 4,
+                    difficulty: 'normal',
+                    gameDurationSeconds: 60,
+                    wordCategory: 'mixed',
+                    players: ['プレイヤー1', 'プレイヤー2', 'プレイヤー3', 'プレイヤー4', 'プレイヤー5', 'プレイヤー6', 'プレイヤー7', 'プレイヤー8'],
+                    teamAssignmentStrategy: 'random',
+                    turnOrderStrategy: 'random'
+                },
+                'minimal': {
+                    name: '最小構成',
+                    teamCount: 2,
+                    difficulty: 'easy',
+                    gameDurationSeconds: 15,
+                    wordCategory: 'colors',
+                    players: ['Player1', 'Player2'],
+                    teamAssignmentStrategy: 'sequential',
+                    turnOrderStrategy: 'sequential'
+                },
+                'full-config': {
+                    name: 'フル機能テスト',
+                    teamCount: 6,
+                    difficulty: 'hard',
+                    gameDurationSeconds: 120,
+                    wordCategory: 'school',
+                    players: ['あきら', 'かずき', 'さくら', 'たろう', 'なおき', 'はなこ', 'みさき', 'ゆうた', 'りな', 'わかな', 'そうた', 'えみ'],
+                    teamAssignmentStrategy: 'manual',
+                    turnOrderStrategy: 'alphabetical'
+                }
+            };
+
+            // プリセット読み込みボタンのイベントリスナー
+            const quickLoadBtn = document.getElementById('quick-load-preset-btn');
+            const quickPresetSelect = document.getElementById('quick-preset-select');
+
+            if (quickLoadBtn && quickPresetSelect) {
+                quickLoadBtn.addEventListener('click', function() {
+                    const selectedPreset = quickPresetSelect.value;
+
+                    if (!selectedPreset) {
+                        alert('プリセットを選択してください');
+                        return;
+                    }
+
+                    const preset = presets[selectedPreset];
+                    if (!preset) {
+                        alert('選択されたプリセットが見つかりません');
+                        return;
+                    }
+
+                    console.log('プリセット適用開始:', preset.name);
+
+                    // フォームに値を設定
+                    applyPresetToForm(preset);
+
+                    // 成功メッセージ表示
+                    alert(`プリセット "${preset.name}" を適用しました！\n\n設定画面で詳細を確認してください。`);
+
+                    console.log('✅ プリセット適用完了:', preset.name);
+                });
+
+                console.log('✅ プリセットボタンのイベントリスナーを設定しました');
+            } else {
+                console.error('❌ プリセットボタンまたはセレクトが見つかりません');
+            }
+
+            // プリセットをフォームに適用する関数
+            function applyPresetToForm(preset) {
+                // 設定名
+                const configNameInput = document.getElementById('config-name');
+                if (configNameInput) configNameInput.value = preset.name;
+
+                // チーム数
+                const teamCountSelect = document.getElementById('team-count');
+                if (teamCountSelect) teamCountSelect.value = preset.teamCount.toString();
+
+                // 難易度
+                const difficultySelect = document.getElementById('difficulty');
+                if (difficultySelect) difficultySelect.value = preset.difficulty;
+
+                // ゲーム時間
+                const gameDurationSelect = document.getElementById('game-duration');
+                if (gameDurationSelect) gameDurationSelect.value = preset.gameDurationSeconds.toString();
+
+                // お題カテゴリ
+                const wordCategorySelect = document.getElementById('word-category');
+                if (wordCategorySelect) wordCategorySelect.value = preset.wordCategory;
+
+                // 割り当て方法
+                const assignmentStrategySelect = document.getElementById('assignment-strategy');
+                if (assignmentStrategySelect) assignmentStrategySelect.value = preset.teamAssignmentStrategy;
+
+                const turnOrderStrategySelect = document.getElementById('turn-order-strategy');
+                if (turnOrderStrategySelect) turnOrderStrategySelect.value = preset.turnOrderStrategy;
+
+                console.log('フォーム設定値の適用が完了しました');
+            }
+
+            // フォールバックスクリプト
             const startBtn = document.getElementById('start-game-btn');
             if (startBtn && startBtn.disabled) {
-                // ボタンが無効な場合は有効にする
                 startBtn.disabled = false;
                 console.log('フォールバック: ゲーム開始ボタンを有効化しました');
             }
-            
-            // ボタンクリックイベントを追加（まだ追加されていない場合）
+
             if (startBtn && !startBtn.onclick) {
                 startBtn.onclick = function() {
                     alert('デモモード: ゲームを開始します！\n\n実際のゲーム機能を実装するには、renderer.jsの読み込みが必要です。');

--- a/src/presentation/simple-renderer.js
+++ b/src/presentation/simple-renderer.js
@@ -26,8 +26,361 @@ class SimpleGameUI {
         
         this.initializeUI();
         this.setupEventListeners();
+        this.initializeDevPresets(); // 開発用プリセット機能を初期化
         
         console.log('SimpleGameUI初期化完了:', this);
+    }
+    
+    initializeDevPresets() {
+        console.log('=== 開発プリセット初期化開始 ===');
+
+        // DOM要素の存在確認
+        const devPresetsSection = document.getElementById('dev-presets');
+        console.log('dev-presetsセクション:', devPresetsSection);
+
+        if (!devPresetsSection) {
+            console.error('❌ CRITICAL: dev-presetsセクションが見つかりません！HTMLを確認してください。');
+            return;
+        }
+
+        // 開発環境の判定結果をログに出力
+        const isDev = this.isDevEnvironment();
+        console.log('URL:', window.location.href);
+        console.log('プロトコル:', window.location.protocol);
+        console.log('ホスト名:', window.location.hostname);
+        console.log('ポート:', window.location.port);
+        console.log('開発環境判定:', isDev);
+
+        // 強制的に表示する（開発環境判定に関係なく）
+        console.log('🔧 デバッグ目的で強制的にプリセットを表示します');
+        devPresetsSection.style.display = 'flex';
+        devPresetsSection.style.visibility = 'visible';
+        devPresetsSection.style.opacity = '1';
+        console.log('✅ 開発プリセットセクションを強制表示しました。');
+
+        // プリセット選択肢を生成
+        setTimeout(() => {
+            this.loadPresetOptions();
+
+            // プリセット読み込みボタンのイベントリスナー設定
+            const loadPresetBtn = document.getElementById('load-preset-btn');
+            if (loadPresetBtn) {
+                loadPresetBtn.addEventListener('click', () => this.loadPresetConfig());
+                console.log('✅ プリセット読み込みボタンのイベントリスナーを設定しました。');
+            } else {
+                console.error('❌ load-preset-btnが見つかりません。');
+            }
+
+            // 自動でデフォルトプリセットを読み込む
+            if (isDev) {
+                this.autoLoadDefaultPreset();
+            }
+        }, 100);
+    }
+    
+    isDevEnvironment() {
+        // Electronアプリの場合の判定ロジック
+
+        // 1. URLパラメータでの指定
+        if (window.location.search.includes('dev=true')) {
+            return true;
+        }
+
+        // 2. Electronの開発環境判定（window.require が利用可能な場合）
+        if (typeof window.require !== 'undefined') {
+            try {
+                const { ipcRenderer } = window.require('electron');
+                // IPCでメインプロセスから環境情報を取得することも可能
+            } catch (e) {
+                // requireが使えない場合は無視
+            }
+        }
+
+        // 3. ファイルプロトコルの場合は開発環境として判定
+        if (window.location.protocol === 'file:') {
+            return true;
+        }
+
+        // 4. 通常のWeb環境での判定（fallback）
+        return window.location.hostname === 'localhost' ||
+               window.location.hostname === '127.0.0.1' ||
+               window.location.port !== '';
+    }
+    
+    loadPresetOptions() {
+        const presetSelect = document.getElementById('preset-select');
+        if (!presetSelect) {
+            console.error('❌ preset-selectが見つかりません。');
+            return;
+        }
+
+        console.log('📋 プリセット選択肢を生成中...');
+
+        // 開発用プリセット設定（JSONファイルの内容を直接埋め込み）
+        const devPresets = {
+            "quick-2team": {
+                name: "クイック2チーム",
+                description: "2チームでの動作確認用"
+            },
+            "multi-team": {
+                name: "マルチチーム",
+                description: "多チームでの動作確認用"
+            },
+            "minimal": {
+                name: "最小構成",
+                description: "最小限の設定でのテスト用"
+            },
+            "full-config": {
+                name: "フル機能テスト",
+                description: "すべての機能を有効にしたテスト用"
+            }
+        };
+
+        // 選択肢をクリア
+        presetSelect.innerHTML = '<option value="">プリセットを選択...</option>';
+
+        // プリセット選択肢を追加
+        Object.entries(devPresets).forEach(([key, preset]) => {
+            const option = document.createElement('option');
+            option.value = key;
+            option.textContent = `${preset.name} - ${preset.description}`;
+            presetSelect.appendChild(option);
+        });
+
+        console.log(`✅ ${Object.keys(devPresets).length}個のプリセット選択肢を追加しました。`);
+    }
+    
+    loadPresetConfig() {
+        const presetSelect = document.getElementById('preset-select');
+        const presetKey = presetSelect?.value;
+        
+        if (!presetKey) {
+            alert('プリセットを選択してください。');
+            return;
+        }
+        
+        try {
+            const config = this.getPresetConfig(presetKey);
+            if (config) {
+                this.applyPresetConfig(config);
+                console.log(`プリセット設定を適用しました: ${presetKey}`);
+                
+                // 成功通知
+                const statusElement = document.getElementById('setup-status');
+                if (statusElement) {
+                    statusElement.textContent = `プリセット "${config.name}" を読み込みました`;
+                    statusElement.style.color = 'green';
+                    
+                    // 3秒後に元に戻す
+                    setTimeout(() => {
+                        statusElement.textContent = '設定を確認してください';
+                        statusElement.style.color = '';
+                    }, 3000);
+                }
+            }
+        } catch (error) {
+            console.error('プリセット設定の読み込みに失敗しました:', error);
+            alert('プリセット設定の読み込みに失敗しました。');
+        }
+    }
+    
+    getPresetConfig(presetKey) {
+        // 開発用プリセット設定
+        const presets = {
+            "quick-2team": {
+                name: "クイック2チーム",
+                teamCount: 2,
+                difficulty: "easy",
+                gameDurationSeconds: 30,
+                wordCategory: "animals",
+                players: ["テストプレイヤー1", "テストプレイヤー2", "テストプレイヤー3", "テストプレイヤー4"],
+                teamAssignmentStrategy: "sequential",
+                turnOrderStrategy: "sequential",
+                soundSettings: {
+                    masterVolume: 50,
+                    soundEffectsEnabled: true,
+                    typingSoundEnabled: true,
+                    backgroundMusicEnabled: false
+                }
+            },
+            "multi-team": {
+                name: "マルチチーム",
+                teamCount: 4,
+                difficulty: "normal", 
+                gameDurationSeconds: 60,
+                wordCategory: "mixed",
+                players: ["プレイヤー1", "プレイヤー2", "プレイヤー3", "プレイヤー4", "プレイヤー5", "プレイヤー6", "プレイヤー7", "プレイヤー8"],
+                teamAssignmentStrategy: "random",
+                turnOrderStrategy: "random",
+                soundSettings: {
+                    masterVolume: 70,
+                    soundEffectsEnabled: true,
+                    typingSoundEnabled: true,
+                    backgroundMusicEnabled: true
+                }
+            },
+            "minimal": {
+                name: "最小構成",
+                teamCount: 2,
+                difficulty: "easy",
+                gameDurationSeconds: 15,
+                wordCategory: "colors", 
+                players: ["Player1", "Player2"],
+                teamAssignmentStrategy: "sequential",
+                turnOrderStrategy: "sequential",
+                soundSettings: {
+                    masterVolume: 0,
+                    soundEffectsEnabled: false,
+                    typingSoundEnabled: false,
+                    backgroundMusicEnabled: false
+                }
+            },
+            "full-config": {
+                name: "フル機能テスト",
+                teamCount: 6,
+                difficulty: "hard",
+                gameDurationSeconds: 120,
+                wordCategory: "school",
+                players: ["あきら", "かずき", "さくら", "たろう", "なおき", "はなこ", "みさき", "ゆうた", "りな", "わかな", "そうた", "えみ"],
+                teamAssignmentStrategy: "manual",
+                turnOrderStrategy: "alphabetical",
+                soundSettings: {
+                    masterVolume: 100,
+                    soundEffectsEnabled: true,
+                    typingSoundEnabled: true,
+                    backgroundMusicEnabled: true
+                }
+            }
+        };
+        
+        return presets[presetKey] || null;
+    }
+    
+    applyPresetConfig(config) {
+        // 設定名
+        const configNameInput = document.getElementById('config-name');
+        if (configNameInput) {
+            configNameInput.value = config.name;
+        }
+        
+        // チーム数
+        const teamCountSelect = document.getElementById('team-count');
+        if (teamCountSelect) {
+            teamCountSelect.value = config.teamCount.toString();
+        }
+        
+        // 難易度
+        const difficultySelect = document.getElementById('difficulty');
+        if (difficultySelect) {
+            difficultySelect.value = config.difficulty;
+        }
+        
+        // ゲーム時間
+        const gameDurationSelect = document.getElementById('game-duration');
+        if (gameDurationSelect) {
+            gameDurationSelect.value = config.gameDurationSeconds.toString();
+        }
+        
+        // お題カテゴリ
+        const wordCategorySelect = document.getElementById('word-category');
+        if (wordCategorySelect) {
+            wordCategorySelect.value = config.wordCategory;
+        }
+        
+        // 音響設定
+        const masterVolumeSlider = document.getElementById('master-volume');
+        const volumeDisplay = document.getElementById('volume-display');
+        if (masterVolumeSlider && volumeDisplay) {
+            masterVolumeSlider.value = config.soundSettings.masterVolume.toString();
+            volumeDisplay.textContent = `${config.soundSettings.masterVolume}%`;
+        }
+        
+        const soundEffectsCheckbox = document.getElementById('sound-effects');
+        if (soundEffectsCheckbox) {
+            soundEffectsCheckbox.checked = config.soundSettings.soundEffectsEnabled;
+        }
+        
+        const typingSoundCheckbox = document.getElementById('typing-sound');
+        if (typingSoundCheckbox) {
+            typingSoundCheckbox.checked = config.soundSettings.typingSoundEnabled;
+        }
+        
+        const backgroundMusicCheckbox = document.getElementById('background-music');
+        if (backgroundMusicCheckbox) {
+            backgroundMusicCheckbox.checked = config.soundSettings.backgroundMusicEnabled;
+        }
+        
+        // プレイヤーを追加
+        this.clearPlayers();
+        config.players.forEach(playerName => {
+            this.addPlayer(playerName);
+        });
+        
+        // 割り当て方法を設定
+        const assignmentStrategySelect = document.getElementById('assignment-strategy');
+        if (assignmentStrategySelect) {
+            assignmentStrategySelect.value = config.teamAssignmentStrategy;
+        }
+        
+        const turnOrderStrategySelect = document.getElementById('turn-order-strategy');
+        if (turnOrderStrategySelect) {
+            turnOrderStrategySelect.value = config.turnOrderStrategy;
+        }
+    }
+    
+    clearPlayers() {
+        const playersContainer = document.getElementById('players-container');
+        if (playersContainer) {
+            playersContainer.innerHTML = '';
+        }
+        this.updatePlayerCount();
+    }
+    
+    addPlayer(name) {
+        const playersContainer = document.getElementById('players-container');
+        if (!playersContainer) return;
+        
+        const playerElement = document.createElement('div');
+        playerElement.className = 'player-item';
+        playerElement.innerHTML = `
+            <span class="player-name">${name}</span>
+            <button class="btn btn-small btn-danger remove-player-btn">削除</button>
+        `;
+        
+        // 削除ボタンのイベントリスナー
+        const removeBtn = playerElement.querySelector('.remove-player-btn');
+        if (removeBtn) {
+            removeBtn.addEventListener('click', () => {
+                playerElement.remove();
+                this.updatePlayerCount();
+            });
+        }
+        
+        playersContainer.appendChild(playerElement);
+        this.updatePlayerCount();
+    }
+    
+    updatePlayerCount() {
+        const playersContainer = document.getElementById('players-container');
+        const playerCountElement = document.getElementById('player-count');
+        
+        if (playersContainer && playerCountElement) {
+            const count = playersContainer.querySelectorAll('.player-item').length;
+            playerCountElement.textContent = count.toString();
+        }
+    }
+    
+    autoLoadDefaultPreset() {
+        // 開発環境では自動的にデフォルトプリセットを読み込む
+        if (this.isDevEnvironment()) {
+            setTimeout(() => {
+                const presetSelect = document.getElementById('preset-select');
+                if (presetSelect) {
+                    presetSelect.value = 'quick-2team'; // デフォルトプリセット
+                    this.loadPresetConfig();
+                }
+            }, 500); // UI初期化後に実行
+        }
     }
     
     initializeUI() {

--- a/src/presentation/styles/main.css
+++ b/src/presentation/styles/main.css
@@ -1,3 +1,68 @@
+/* 開発用プリセットスタイル */
+.dev-preset-section {
+    display: flex !important; /* 強制表示でテスト */
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+    padding: 10px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 5px;
+    border: 2px dashed #4ECDC4;
+}
+
+.dev-preset-section label {
+    font-size: 0.9rem;
+    color: #4ECDC4;
+    font-weight: bold;
+}
+
+.dev-preset-section select {
+    min-width: 200px;
+}
+
+.btn-accent {
+    background: linear-gradient(135deg, #4ECDC4, #44A08D);
+    color: white;
+    border: none;
+}
+
+.btn-accent:hover {
+    background: linear-gradient(135deg, #44A08D, #4ECDC4);
+    transform: translateY(-2px);
+}
+
+.btn-small {
+    padding: 5px 10px;
+    font-size: 0.8rem;
+}
+
+.player-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    margin: 5px 0;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 5px;
+    border-left: 4px solid #4ECDC4;
+}
+
+.player-name {
+    font-weight: 500;
+    color: #2D3748;
+}
+
+.btn-danger {
+    background: linear-gradient(135deg, #FF6B6B, #EE5A52);
+    color: white;
+    border: none;
+}
+
+.btn-danger:hover {
+    background: linear-gradient(135deg, #EE5A52, #FF6B6B);
+    transform: translateY(-1px);
+}
+
 /* 基本スタイル */
 * {
     margin: 0;

--- a/src/presentation/styles/main.css
+++ b/src/presentation/styles/main.css
@@ -863,6 +863,391 @@ body {
     transform: translateY(-2px);
 }
 
+/* Phase 1.4: プレイヤー管理・メンバー割り当て・ターン順設定 */
+
+/* プレイヤー管理 */
+.player-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.player-input-area {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    padding: 15px;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
+}
+
+.player-input-area input {
+    flex: 1;
+}
+
+.players-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.player-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    min-width: 120px;
+    transition: all 0.3s ease;
+}
+
+.player-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.player-name {
+    font-weight: 500;
+    color: #2d3748;
+}
+
+.remove-player-btn {
+    background: #e53e3e;
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    font-size: 12px;
+    cursor: pointer;
+    margin-left: 8px;
+    transition: all 0.3s ease;
+}
+
+.remove-player-btn:hover {
+    background: #c53030;
+    transform: scale(1.1);
+}
+
+/* チームメンバー割り当て */
+.team-assignment-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.assignment-controls {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    padding: 15px;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
+}
+
+.assignment-strategy {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.team-members-display {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 15px;
+}
+
+.team-members-card {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 8px;
+    padding: 15px;
+    border: 2px solid transparent;
+    transition: all 0.3s ease;
+}
+
+.team-members-card:hover {
+    border-color: #4299e1;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.team-members-header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 15px;
+    gap: 10px;
+}
+
+.team-members-header h4 {
+    margin: 0;
+    color: #2d3748;
+}
+
+.member-count {
+    background: #4299e1;
+    color: white;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+.team-members-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.team-member-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 12px;
+    background: #f7fafc;
+    border-radius: 6px;
+    border: 1px solid #e2e8f0;
+}
+
+.member-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.member-order {
+    background: #4299e1;
+    color: white;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+.member-name {
+    font-weight: 500;
+    color: #2d3748;
+}
+
+.move-member-controls {
+    display: flex;
+    gap: 4px;
+}
+
+.move-member-btn {
+    background: #e2e8f0;
+    border: none;
+    border-radius: 4px;
+    width: 24px;
+    height: 24px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.move-member-btn:hover {
+    background: #cbd5e0;
+    transform: scale(1.1);
+}
+
+/* ターン順設定 */
+.turn-order-section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.turn-order-controls {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    padding: 15px;
+    background: rgba(255, 255, 255, 0.8);
+    border-radius: 8px;
+    border: 1px solid #e2e8f0;
+}
+
+.turn-order-strategy {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.turn-order-display {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 15px;
+}
+
+.turn-order-card {
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: 8px;
+    padding: 15px;
+    border: 2px solid transparent;
+    transition: all 0.3s ease;
+}
+
+.turn-order-card:hover {
+    border-color: #38a169;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.turn-order-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 15px;
+}
+
+.turn-order-header h4 {
+    margin: 0;
+    color: #2d3748;
+}
+
+.current-player-indicator {
+    background: #38a169;
+    color: white;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+.turn-order-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.turn-order-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 12px;
+    background: #f7fafc;
+    border-radius: 6px;
+    border: 1px solid #e2e8f0;
+    transition: all 0.3s ease;
+}
+
+.turn-order-item.current-turn {
+    background: #c6f6d5;
+    border-color: #38a169;
+    box-shadow: 0 0 0 2px rgba(56, 161, 105, 0.2);
+}
+
+.turn-order-item:hover:not(.current-turn) {
+    background: #edf2f7;
+}
+
+.turn-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.turn-number {
+    background: #4a5568;
+    color: white;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.9rem;
+    font-weight: bold;
+}
+
+.turn-order-item.current-turn .turn-number {
+    background: #38a169;
+    animation: currentTurnPulse 2s ease infinite;
+}
+
+@keyframes currentTurnPulse {
+    0%, 100% {
+        box-shadow: 0 0 0 0 rgba(56, 161, 105, 0.5);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(56, 161, 105, 0);
+    }
+}
+
+.turn-player-name {
+    font-weight: 600;
+    color: #2d3748;
+}
+
+.turn-controls {
+    display: flex;
+    gap: 4px;
+}
+
+.set-current-btn {
+    background: #38a169;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.set-current-btn:hover {
+    background: #2f855a;
+    transform: scale(1.05);
+}
+
+.set-current-btn:disabled {
+    background: #e2e8f0;
+    color: #a0aec0;
+    cursor: not-allowed;
+    transform: none;
+}
+
+/* 空のメッセージ */
+.empty-message {
+    text-align: center;
+    padding: 30px;
+    color: #718096;
+    font-style: italic;
+}
+
+.empty-message::before {
+    content: "👥";
+    display: block;
+    font-size: 2rem;
+    margin-bottom: 10px;
+}
+
+/* アニメーション効果 */
+.player-item,
+.team-members-card,
+.turn-order-card {
+    animation: fadeInUp 0.3s ease;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 /* レスポンシブ調整 */
 @media (max-width: 768px) {
     .setup-header {
@@ -870,17 +1255,38 @@ body {
         gap: 15px;
         text-align: center;
     }
-    
+
     .settings-grid {
         grid-template-columns: 1fr;
     }
-    
-    .team-settings {
+
+    .team-settings,
+    .team-members-display,
+    .turn-order-display {
         grid-template-columns: 1fr;
     }
-    
+
     .sound-toggles {
         flex-direction: column;
         align-items: flex-start;
+    }
+
+    .assignment-controls,
+    .turn-order-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .assignment-strategy,
+    .turn-order-strategy {
+        justify-content: space-between;
+    }
+
+    .players-container {
+        flex-direction: column;
+    }
+
+    .player-item {
+        min-width: auto;
     }
 }

--- a/src/shared/types/GameConfig.ts
+++ b/src/shared/types/GameConfig.ts
@@ -46,6 +46,39 @@ export interface TeamSettings {
   assignedKeyboardId?: string;
 }
 
+/** プレイヤー情報 */
+export interface Player {
+  /** プレイヤーID */
+  id: string;
+  
+  /** プレイヤー名 */
+  name: string;
+  
+  /** 作成日時 */
+  createdAt: string;
+}
+
+/** チーム内のメンバー情報 */
+export interface TeamMember {
+  /** プレイヤー情報 */
+  player: Player;
+  
+  /** チーム内でのターン順（0から開始） */
+  turnOrder: number;
+  
+  /** 参加日時 */
+  joinedAt: string;
+}
+
+/** メンバー割り当て済みのチーム設定 */
+export interface TeamWithMembers extends TeamSettings {
+  /** チームメンバー（ターン順にソート済み） */
+  members: TeamMember[];
+  
+  /** 現在のターンのプレイヤーインデックス */
+  currentTurnIndex: number;
+}
+
 export interface KeyboardAssignment {
   /** キーボードID */
   keyboardId: string;

--- a/src/shared/utils/seeded-random.ts
+++ b/src/shared/utils/seeded-random.ts
@@ -14,3 +14,42 @@ export class SeededRandom {
         return min + this.next() * (max - min);
     }
 }
+
+/**
+ * シード値に基づいて配列をシャッフル
+ */
+export function seededShuffle<T>(array: T[], seed?: string): T[] {
+    if (array.length <= 1) return [...array];
+
+    const seedValue = seed ? stringToSeed(seed) : Date.now();
+    const rng = new SeededRandom(seedValue);
+    const result = [...array];
+
+    // Fisher-Yates shuffle algorithm with seeded random
+    for (let i = result.length - 1; i > 0; i--) {
+        const j = Math.floor(rng.next() * (i + 1));
+        [result[i], result[j]] = [result[j], result[i]];
+    }
+
+    return result;
+}
+
+/**
+ * ユニークなIDを生成
+ */
+export function generateId(): string {
+    return `id_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+
+/**
+ * 文字列をシード値に変換
+ */
+function stringToSeed(str: string): number {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+        const char = str.charCodeAt(i);
+        hash = ((hash << 5) - hash) + char;
+        hash = hash & hash; // Convert to 32-bit integer
+    }
+    return Math.abs(hash);
+}

--- a/test-electron-keyboard/index.html
+++ b/test-electron-keyboard/index.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Multi-Keyboard Input Tester</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            margin: 0;
+            padding: 20px;
+            background: #f5f5f5;
+        }
+        
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 8px;
+            padding: 20px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        
+        h1 {
+            color: #333;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+        
+        .section {
+            margin-bottom: 30px;
+            padding: 20px;
+            background: #f8f9fa;
+            border-radius: 6px;
+            border-left: 4px solid #007acc;
+        }
+        
+        .keyboards-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 15px;
+            margin-top: 15px;
+        }
+        
+        .keyboard-card {
+            background: white;
+            padding: 15px;
+            border-radius: 6px;
+            border: 2px solid #e1e5e9;
+            position: relative;
+        }
+        
+        .keyboard-card.active {
+            border-color: #007acc;
+            background: #f0f8ff;
+        }
+        
+        .keyboard-name {
+            font-weight: bold;
+            color: #333;
+            margin-bottom: 8px;
+        }
+        
+        .keyboard-info {
+            font-size: 12px;
+            color: #666;
+            margin-bottom: 10px;
+        }
+        
+        .keyboard-activity {
+            height: 60px;
+            background: #f5f5f5;
+            border-radius: 4px;
+            padding: 10px;
+            font-family: monospace;
+            font-size: 11px;
+            overflow-y: auto;
+            border: 1px solid #ddd;
+        }
+        
+        .input-log {
+            height: 300px;
+            background: #1e1e1e;
+            color: #00ff00;
+            padding: 15px;
+            border-radius: 6px;
+            font-family: 'Monaco', 'Menlo', monospace;
+            font-size: 12px;
+            overflow-y: auto;
+            white-space: pre-wrap;
+        }
+        
+        .controls {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 20px;
+        }
+        
+        button {
+            padding: 8px 16px;
+            border: none;
+            border-radius: 4px;
+            background: #007acc;
+            color: white;
+            cursor: pointer;
+            font-size: 14px;
+        }
+        
+        button:hover {
+            background: #005a9e;
+        }
+        
+        .status {
+            text-align: center;
+            padding: 10px;
+            background: #e7f3ff;
+            border-radius: 4px;
+            margin-bottom: 20px;
+            color: #0066cc;
+        }
+        
+        .timestamp {
+            color: #888;
+            font-size: 10px;
+        }
+        
+        .key-display {
+            display: inline-block;
+            background: #333;
+            color: white;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: monospace;
+            margin-right: 5px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>🎹 Multi-Keyboard Input Tester</h1>
+        
+        <div class="status" id="status">
+            初期化中...
+        </div>
+        
+        <div class="section">
+            <h3>🔍 検知されたキーボード</h3>
+            <div id="keyboards-info">
+                検知中...
+            </div>
+            <div class="keyboards-grid" id="keyboards-grid">
+                <!-- キーボードカードがここに表示されます -->
+            </div>
+        </div>
+        
+        <div class="section">
+            <h3>⌨️ リアルタイム入力監視</h3>
+            <p>このウィンドウをアクティブにして、異なるキーボードでタイピングしてください。</p>
+            <div class="controls">
+                <button onclick="clearLog()">ログクリア</button>
+                <button onclick="togglePause()" id="pauseBtn">一時停止</button>
+                <button onclick="exportLog()">ログエクスポート</button>
+            </div>
+            <div class="input-log" id="input-log">
+=== 入力監視開始 ===
+キーボードで何かタイピングしてください...
+
+            </div>
+        </div>
+    </div>
+
+    <script src="renderer.js"></script>
+</body>
+</html>

--- a/test-electron-keyboard/main.js
+++ b/test-electron-keyboard/main.js
@@ -1,0 +1,297 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('path');
+
+// Native Addonを使って実際のキーボード検知
+let keyboardDetector;
+try {
+    const { KeyboardDetector } = require('./native-keyboard-addon/index.js');
+    keyboardDetector = new KeyboardDetector();
+    console.log('Native keyboard detector loaded successfully');
+} catch (error) {
+    console.warn('Native keyboard detector not available, using mock data:', error.message);
+}
+
+class KeyboardTester {
+    constructor() {
+        this.mainWindow = null;
+        this.detectedKeyboards = [];
+        this.inputHistory = [];
+        this.keyboardAssignments = new Map(); // タイミングベースでキーボード推定
+    }
+
+    async createWindow() {
+        this.mainWindow = new BrowserWindow({
+            width: 1200,
+            height: 800,
+            webPreferences: {
+                nodeIntegration: false,
+                contextIsolation: true,
+                preload: path.join(__dirname, 'preload.js')
+            },
+            title: 'Multi-Keyboard Input Tester'
+        });
+
+        await this.mainWindow.loadFile('index.html');
+        
+        // 開発時はDevToolsを開く
+        if (process.argv.includes('--dev')) {
+            this.mainWindow.webContents.openDevTools();
+        }
+
+        this.setupKeyboardDetection();
+        this.setupInputHandling();
+        this.setupRealKeyboardInput();
+    }
+
+    setupKeyboardDetection() {
+        console.log('=== キーボード検知開始 ===');
+
+        try {
+            if (keyboardDetector) {
+                // Native Addonによるキーボード検知
+                console.log('Native Addonでキーボード検知を初期化...');
+                const initialized = keyboardDetector.initialize();
+
+                if (initialized) {
+                    console.log('Native Addon初期化成功、キーボードスキャン開始...');
+                    const detectedKeyboards = keyboardDetector.scanKeyboards();
+
+                    this.detectedKeyboards = detectedKeyboards.map((device, index) => ({
+                        id: `kb-${index + 1}`,
+                        name: device.name || `Keyboard ${index + 1}`,
+                        manufacturer: device.manufacturer || 'Unknown',
+                        vendorId: device.vendorId,
+                        productId: device.productId,
+                        locationId: device.locationId,
+                        method: 'native-addon'
+                    }));
+
+                    console.log(`Native Addon検知: ${this.detectedKeyboards.length}個のキーボード`);
+                    this.detectedKeyboards.forEach((kb, i) => {
+                        console.log(`  ${i + 1}. ${kb.name} (${kb.manufacturer})`);
+                        console.log(`     Vendor: 0x${kb.vendorId.toString(16)}, Product: 0x${kb.productId.toString(16)}`);
+                    });
+                } else {
+                    console.error('Native Addon初期化失敗');
+                    throw new Error('Native Addon initialization failed');
+                }
+            } else {
+                throw new Error('Native keyboard detector not available');
+            }
+        } catch (error) {
+            console.error('キーボード検知エラー:', error);
+            // フォールバック: モックデータ
+            this.detectedKeyboards = [
+                {
+                    id: 'kb-1',
+                    name: 'Mock Keyboard 1',
+                    manufacturer: 'Mock Inc.',
+                    vendorId: 0x1234,
+                    productId: 0x5678,
+                    locationId: 0x01,
+                    method: 'mock'
+                },
+                {
+                    id: 'kb-2',
+                    name: 'Mock Keyboard 2',
+                    manufacturer: 'Mock Corp.',
+                    vendorId: 0x9ABC,
+                    productId: 0xDEF0,
+                    locationId: 0x02,
+                    method: 'mock'
+                }
+            ];
+            console.log('フォールバック: モックデータ使用');
+        }
+
+        // レンダラーにキーボード情報を送信
+        this.sendToRenderer('keyboards-detected', this.detectedKeyboards);
+    }
+
+    setupRealKeyboardInput() {
+        console.log('=== リアルキーボード入力監視設定 ===');
+
+        if (!keyboardDetector) {
+            console.warn('Native keyboard detector not available, skipping real input setup');
+            return;
+        }
+
+        try {
+            // Native Addonによる直接キーイベントキャプチャ
+            const success = keyboardDetector.setKeyEventCallback((keyEvent) => {
+                console.log(`🎹 Real Input - KB-${keyEvent.keyboardId}: "${keyEvent.keyName}"`);
+
+                // 正確なキーボードIDを含むイベントを送信
+                const realKeyEvent = {
+                    key: keyEvent.keyName,
+                    code: keyEvent.keyName, // HIDからは直接codeが取れないので同じ値を使用
+                    keyboardId: `kb-${keyEvent.keyboardId}`,
+                    timestamp: Date.now(),
+                    source: 'native-direct',
+                    rawData: {
+                        usagePage: keyEvent.usagePage,
+                        usage: keyEvent.usage,
+                        value: keyEvent.value,
+                        nativeTimestamp: keyEvent.timestamp
+                    }
+                };
+
+                // 入力履歴に追加
+                this.inputHistory.push(realKeyEvent);
+                if (this.inputHistory.length > 100) {
+                    this.inputHistory.shift();
+                }
+
+                // レンダラーに送信
+                this.sendToRenderer('real-key-input', realKeyEvent);
+            });
+
+            if (success) {
+                console.log('✅ リアルキーボード入力監視が開始されました');
+                console.log('💡 これで物理的に異なるキーボードからの入力を個別に識別できます');
+            } else {
+                console.error('❌ リアルキーボード入力監視の開始に失敗');
+            }
+        } catch (error) {
+            console.error('リアルキーボード入力設定エラー:', error);
+        }
+    }
+
+    setupInputHandling() {
+        console.log('=== 入力監視設定 ===');
+        
+        // Electronの入力イベント監視
+        this.mainWindow.webContents.on('before-input-event', (event, input) => {
+            if (input.type === 'keyDown') {
+                this.handleKeyInput(input);
+            }
+        });
+
+        // ウィンドウフォーカスイベント
+        this.mainWindow.on('focus', () => {
+            console.log('ウィンドウフォーカス取得');
+        });
+
+        this.mainWindow.on('blur', () => {
+            console.log('ウィンドウフォーカス喪失');
+        });
+    }
+
+    handleKeyInput(input) {
+        const timestamp = Date.now();
+        const keyboardId = this.estimateKeyboardSource(input, timestamp);
+        
+        const keyEvent = {
+            key: input.key,
+            code: input.code,
+            keyboardId: keyboardId,
+            timestamp: timestamp,
+            modifiers: {
+                shift: input.shift,
+                control: input.control,
+                alt: input.alt,
+                meta: input.meta
+            }
+        };
+
+        console.log(`⌨️ キー入力: "${input.key}" -> ${keyboardId} (${timestamp})`);
+        
+        // 入力履歴に追加
+        this.inputHistory.push(keyEvent);
+        if (this.inputHistory.length > 100) {
+            this.inputHistory.shift(); // 古い履歴を削除
+        }
+
+        // レンダラーに送信
+        this.sendToRenderer('key-input', keyEvent);
+    }
+
+    estimateKeyboardSource(input, timestamp) {
+        // 改良版キーボード推定ロジック
+        const recentInputs = this.inputHistory.slice(-10); // 最近の10個の入力
+
+        if (recentInputs.length === 0) {
+            return this.detectedKeyboards[0]?.id || 'kb-1';
+        }
+
+        const lastInput = recentInputs[recentInputs.length - 1];
+        const timeDiff = timestamp - lastInput.timestamp;
+
+        // アプローチ1: 連続入力判定（同じキーボード）
+        if (timeDiff < 300) {
+            // 300ms以内の高速連続入力 = 同じキーボードの可能性が高い
+            console.log(`高速連続入力: ${lastInput.keyboardId} 継続 (間隔: ${timeDiff}ms)`);
+            return lastInput.keyboardId;
+        }
+
+        // アプローチ2: タイミング解析（キーボード切り替え）
+        if (timeDiff > 800) {
+            // 800ms以上の間隔 = 異なるキーボードの可能性
+            const currentIndex = this.detectedKeyboards.findIndex(kb => kb.id === lastInput.keyboardId);
+            const nextKeyboardId = this.detectedKeyboards[(currentIndex + 1) % this.detectedKeyboards.length]?.id || 'kb-1';
+            console.log(`長い間隔での切替: ${lastInput.keyboardId} -> ${nextKeyboardId} (間隔: ${timeDiff}ms)`);
+            return nextKeyboardId;
+        }
+
+        // アプローチ3: 修飾キーパターン分析
+        if (input.shift && input.key.length === 1) {
+            // Shift + 文字 = キーボード2優先
+            const shiftKeyboardId = this.detectedKeyboards[1]?.id || 'kb-2';
+            console.log(`Shift修飾キー検出: ${shiftKeyboardId} 選択`);
+            return shiftKeyboardId;
+        }
+
+        if (input.control || input.alt || input.meta) {
+            // Ctrl/Alt/Cmd修飾キー = キーボード1優先
+            const ctrlKeyboardId = this.detectedKeyboards[0]?.id || 'kb-1';
+            console.log(`Ctrl/Alt/Cmd修飾キー検出: ${ctrlKeyboardId} 選択`);
+            return ctrlKeyboardId;
+        }
+
+        // アプローチ4: 中間間隔の場合は前回と同じキーボードを維持
+        console.log(`中間間隔: ${lastInput.keyboardId} 維持 (間隔: ${timeDiff}ms)`);
+        return lastInput.keyboardId;
+    }
+
+    sendToRenderer(channel, data) {
+        if (this.mainWindow) {
+            this.mainWindow.webContents.send(channel, data);
+        }
+    }
+
+    // IPCハンドラー
+    setupIPC() {
+        ipcMain.handle('get-keyboards', () => {
+            return this.detectedKeyboards;
+        });
+
+        ipcMain.handle('get-input-history', () => {
+            return this.inputHistory;
+        });
+
+        ipcMain.handle('clear-history', () => {
+            this.inputHistory = [];
+            return { success: true };
+        });
+    }
+}
+
+// Electronアプリケーション初期化
+const keyboardTester = new KeyboardTester();
+
+app.whenReady().then(() => {
+    keyboardTester.setupIPC();
+    keyboardTester.createWindow();
+});
+
+app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') {
+        app.quit();
+    }
+});
+
+app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+        keyboardTester.createWindow();
+    }
+});

--- a/test-electron-keyboard/native-keyboard-addon/binding.gyp
+++ b/test-electron-keyboard/native-keyboard-addon/binding.gyp
@@ -1,0 +1,45 @@
+{
+  "targets": [
+    {
+      "target_name": "keyboard_detector",
+      "sources": [],
+      "conditions": [
+        ["OS=='mac'", {
+          "sources": [
+            "src/keyboard_detector_mac.mm"
+          ],
+          "link_settings": {
+            "libraries": [
+              "-framework IOKit",
+              "-framework Foundation",
+              "-framework AppKit"
+            ]
+          },
+          "xcode_settings": {
+            "CLANG_CXX_LIBRARY": "libc++",
+            "MACOSX_DEPLOYMENT_TARGET": "10.14",
+            "GCC_ENABLE_CPP_EXCEPTIONS": "YES"
+          }
+        }],
+        ["OS=='win'", {
+          "sources": [
+            "src/keyboard_detector_win.cpp"
+          ],
+          "libraries": [
+            "user32.lib"
+          ]
+        }],
+        ["OS=='linux'", {
+          "sources": [
+            "src/keyboard_detector_linux.cpp"
+          ]
+        }]
+      ],
+      "include_dirs": [
+        "<!@(node -p \"require('node-addon-api').include\")"
+      ],
+      "dependencies": [],
+      "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS"]
+    }
+  ]
+}

--- a/test-electron-keyboard/native-keyboard-addon/index.js
+++ b/test-electron-keyboard/native-keyboard-addon/index.js
@@ -1,0 +1,192 @@
+const path = require('path');
+const os = require('os');
+
+let nativeAddon;
+
+try {
+    // プラットフォーム別のネイティブアドオンをロード
+    const platform = os.platform();
+    const addonPath = path.join(__dirname, 'build', 'Release', 'keyboard_detector.node');
+
+    console.log(`Loading native addon for platform: ${platform}`);
+    console.log(`Addon path: ${addonPath}`);
+
+    nativeAddon = require(addonPath);
+    console.log('Native addon loaded successfully');
+
+} catch (error) {
+    console.error('Failed to load native addon:', error.message);
+    console.error('Build the addon with: npm run build');
+
+    // フォールバック: ダミー実装
+    nativeAddon = {
+        initialize: () => {
+            console.log('Using fallback implementation - native addon not available');
+            return false;
+        },
+        scanKeyboards: () => {
+            console.log('Fallback: No keyboards detected');
+            return [];
+        },
+        getKeyboardCount: () => {
+            console.log('Fallback: 0 keyboards');
+            return 0;
+        }
+    };
+}
+
+class KeyboardDetector {
+    constructor() {
+        this.initialized = false;
+        this.keyEventCallback = null;
+    }
+
+    /**
+     * IOHIDManagerを初期化
+     * @returns {boolean} 初期化成功
+     */
+    initialize() {
+        try {
+            console.log('Initializing keyboard detector...');
+            this.initialized = nativeAddon.initialize();
+            console.log(`Initialization ${this.initialized ? 'successful' : 'failed'}`);
+            return this.initialized;
+        } catch (error) {
+            console.error('Error during initialization:', error);
+            return false;
+        }
+    }
+
+    /**
+     * 接続されているキーボードをスキャン
+     * @returns {Array} キーボード情報の配列
+     */
+    scanKeyboards() {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return [];
+        }
+
+        try {
+            console.log('Scanning for keyboards...');
+            const keyboards = nativeAddon.scanKeyboards();
+            console.log(`Found ${keyboards.length} keyboard(s)`);
+
+            keyboards.forEach((kbd, index) => {
+                console.log(`Keyboard ${index + 1}:`);
+                console.log(`  Name: ${kbd.name}`);
+                console.log(`  Manufacturer: ${kbd.manufacturer}`);
+                console.log(`  Vendor ID: 0x${kbd.vendorId.toString(16)}`);
+                console.log(`  Product ID: 0x${kbd.productId.toString(16)}`);
+                console.log(`  Location ID: 0x${kbd.locationId.toString(16)}`);
+            });
+
+            return keyboards;
+        } catch (error) {
+            console.error('Error during keyboard scan:', error);
+            return [];
+        }
+    }
+
+    /**
+     * 検知されたキーボード数を取得
+     * @returns {number} キーボード数
+     */
+    getKeyboardCount() {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return 0;
+        }
+
+        try {
+            const count = nativeAddon.getKeyboardCount();
+            console.log(`Total keyboards: ${count}`);
+            return count;
+        } catch (error) {
+            console.error('Error getting keyboard count:', error);
+            return 0;
+        }
+    }
+
+    /**
+     * キーイベントのコールバック関数を設定
+     * @param {function} callback キーイベントを受け取るコールバック関数
+     */
+    setKeyEventCallback(callback) {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return false;
+        }
+
+        try {
+            this.keyEventCallback = callback;
+            const success = nativeAddon.setKeyEventCallback(callback);
+            console.log(`Key event callback ${success ? 'registered' : 'failed to register'}`);
+            return success;
+        } catch (error) {
+            console.error('Error setting key event callback:', error);
+            return false;
+        }
+    }
+
+    /**
+     * キューから次のキーイベントを取得（ポーリング用）
+     * @returns {Object|null} キーイベントオブジェクト、またはnull
+     */
+    getNextKeyEvent() {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return null;
+        }
+
+        try {
+            return nativeAddon.getNextKeyEvent();
+        } catch (error) {
+            console.error('Error getting next key event:', error);
+            return null;
+        }
+    }
+
+    /**
+     * キーイベントのポーリングを開始
+     * @param {function} callback キーイベントを受け取るコールバック関数
+     * @param {number} intervalMs ポーリング間隔（ミリ秒）
+     */
+    startKeyEventPolling(callback, intervalMs = 10) {
+        if (!this.initialized) {
+            console.warn('Detector not initialized. Call initialize() first.');
+            return null;
+        }
+
+        const pollInterval = setInterval(() => {
+            const keyEvent = this.getNextKeyEvent();
+            if (keyEvent) {
+                callback(keyEvent);
+            }
+        }, intervalMs);
+
+        console.log(`Key event polling started (interval: ${intervalMs}ms)`);
+        return pollInterval;
+    }
+
+    /**
+     * キーイベントのポーリングを停止
+     * @param {number} pollInterval startKeyEventPollingから返されたinterval ID
+     */
+    stopKeyEventPolling(pollInterval) {
+        if (pollInterval) {
+            clearInterval(pollInterval);
+            console.log('Key event polling stopped');
+        }
+    }
+}
+
+module.exports = {
+    KeyboardDetector,
+    // 直接関数のエクスポートも提供
+    initialize: () => nativeAddon.initialize(),
+    scanKeyboards: () => nativeAddon.scanKeyboards(),
+    getKeyboardCount: () => nativeAddon.getKeyboardCount(),
+    setKeyEventCallback: (callback) => nativeAddon.setKeyEventCallback(callback),
+    getNextKeyEvent: () => nativeAddon.getNextKeyEvent()
+};

--- a/test-electron-keyboard/native-keyboard-addon/package-lock.json
+++ b/test-electron-keyboard/native-keyboard-addon/package-lock.json
@@ -1,0 +1,1274 @@
+{
+  "name": "native-keyboard-detector",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "native-keyboard-detector",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.0.0"
+      },
+      "devDependencies": {
+        "node-gyp": "^10.0.1"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-2.2.2.tgz",
+      "integrity": "sha512-OrcNPXdpSl9UX7qPVRWbmWMCSXrcDa2M9DvrbOTj7ao1S4PlqVFYv9/yLKMkrJKZ/V5A/kDBC690or307i26Og==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-18.0.4.tgz",
+      "integrity": "sha512-B+L5iIa9mgcjLbliir2th36yEwPftrzteHYujzsx3dFP/31GCHcIeS8f5MGd80odLOjaOvSpU3EEAmRQptkxLQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^4.0.0",
+        "ssri": "^10.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^3.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-13.0.1.tgz",
+      "integrity": "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^2.0.0",
+        "cacache": "^18.0.0",
+        "http-cache-semantics": "^4.1.1",
+        "is-lambda": "^1.0.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^3.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "proc-log": "^4.2.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^10.0.0"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-3.0.5.tgz",
+      "integrity": "sha512-2N8elDQAtSnFV0Dk7gt15KHsS0Fyz6CbYZ360h0WTYV1Ty46li3rAXVOQj1THMNLdmrD9Vt5pBPtWtVkpwGBqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-10.3.1.tgz",
+      "integrity": "sha512-Pp3nFHBThHzVtNY7U6JfPjvT/DTE8+o/4xKsLQtBoU+j2HLsGlhcfzflAoUreaJbNmYnX+LlLi0qjV8kpyO6xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^10.3.10",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^13.0.0",
+        "nopt": "^7.0.0",
+        "proc-log": "^4.1.0",
+        "semver": "^7.3.5",
+        "tar": "^6.2.1",
+        "which": "^4.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ssri": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-10.0.6.tgz",
+      "integrity": "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
+      "integrity": "sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-4.0.0.tgz",
+      "integrity": "sha512-WrcA6AyEfqDX5bWige/4NQfPZMtASNVxdmWR76WESYQVAACSgWcR6e9i0mofqqBxYFtL4oAxPIptY73/0YE1DQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
+      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/test-electron-keyboard/native-keyboard-addon/package.json
+++ b/test-electron-keyboard/native-keyboard-addon/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "native-keyboard-detector",
+  "version": "1.0.0",
+  "description": "Native keyboard detection addon for Electron apps",
+  "main": "index.js",
+  "scripts": {
+    "build": "node-gyp rebuild",
+    "clean": "node-gyp clean",
+    "test": "node test.js"
+  },
+  "dependencies": {
+    "node-addon-api": "^7.0.0"
+  },
+  "devDependencies": {
+    "node-gyp": "^10.0.1"
+  },
+  "gypfile": true,
+  "author": "Takatomo Ezo",
+  "license": "MIT"
+}

--- a/test-electron-keyboard/native-keyboard-addon/src/keyboard_detector_mac.mm
+++ b/test-electron-keyboard/native-keyboard-addon/src/keyboard_detector_mac.mm
@@ -1,0 +1,564 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+#import <IOKit/hid/IOHIDManager.h>
+#import <IOKit/hid/IOHIDKeys.h>
+#import <IOKit/hid/IOHIDValue.h>
+#import <IOKit/hid/IOHIDElement.h>
+#include <node_api.h>
+#include <uv.h>
+#include <vector>
+#include <map>
+#include <string>
+#include <iostream>
+#include <queue>
+#include <memory>
+#include <thread>
+#include <mutex>
+
+struct KeyboardDevice {
+    std::string name;
+    std::string manufacturer;
+    uint32_t vendorId;
+    uint32_t productId;
+    uint32_t locationId;
+    IOHIDDeviceRef device;
+    int keyboardId;  // 識別用ID
+};
+
+struct KeyEvent {
+    int keyboardId;
+    uint32_t usagePage;
+    uint32_t usage;
+    int32_t value;
+    uint64_t timestamp;
+    std::string keyName;
+};
+
+// AsyncDataは削除（使用しない）
+
+class KeyboardDetector {
+public:
+    std::queue<KeyEvent> keyEventQueue;
+    std::mutex queueMutex;
+    napi_threadsafe_function keyEventCallback;
+
+private:
+    IOHIDManagerRef hidManager;
+    std::vector<KeyboardDevice> keyboards;
+    std::map<IOHIDDeviceRef, int> deviceToKeyboardMap;
+
+public:
+    KeyboardDetector() : keyEventCallback(nullptr), hidManager(nullptr) {}
+
+    ~KeyboardDetector() {
+        if (keyEventCallback) {
+            napi_release_threadsafe_function(keyEventCallback, napi_tsfn_release);
+        }
+        if (hidManager) {
+            IOHIDManagerClose(hidManager, kIOHIDOptionsTypeNone);
+            CFRelease(hidManager);
+        }
+    }
+
+    bool initialize() {
+        hidManager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+        if (!hidManager) {
+            std::cerr << "Failed to create IOHIDManager" << std::endl;
+            return false;
+        }
+
+        // Set up matching dictionary for keyboards
+        CFMutableDictionaryRef matchingDict = CFDictionaryCreateMutable(
+            kCFAllocatorDefault, 0,
+            &kCFTypeDictionaryKeyCallBacks,
+            &kCFTypeDictionaryValueCallBacks);
+
+        if (!matchingDict) {
+            std::cerr << "Failed to create matching dictionary" << std::endl;
+            return false;
+        }
+
+        // Match HID keyboards (usage page 1, usage 6)
+        int usagePage = kHIDPage_GenericDesktop;
+        int usage = kHIDUsage_GD_Keyboard;
+
+        CFNumberRef usagePageRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usagePage);
+        CFNumberRef usageRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usage);
+
+        CFDictionarySetValue(matchingDict, CFSTR(kIOHIDDeviceUsagePageKey), usagePageRef);
+        CFDictionarySetValue(matchingDict, CFSTR(kIOHIDDeviceUsageKey), usageRef);
+
+        IOHIDManagerSetDeviceMatching(hidManager, matchingDict);
+
+        // Register callbacks
+        IOHIDManagerRegisterDeviceMatchingCallback(hidManager, deviceMatchingCallback, this);
+        IOHIDManagerRegisterDeviceRemovalCallback(hidManager, deviceRemovalCallback, this);
+
+        // Schedule with run loop
+        IOHIDManagerScheduleWithRunLoop(hidManager, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+
+        // Open the manager
+        IOReturn result = IOHIDManagerOpen(hidManager, kIOHIDOptionsTypeNone);
+        if (result != kIOReturnSuccess) {
+            std::cerr << "Failed to open IOHIDManager: " << result << std::endl;
+            CFRelease(matchingDict);
+            CFRelease(usagePageRef);
+            CFRelease(usageRef);
+            return false;
+        }
+
+        std::cout << "IOHIDManager initialized successfully" << std::endl;
+
+        // Clean up
+        CFRelease(matchingDict);
+        CFRelease(usagePageRef);
+        CFRelease(usageRef);
+
+        return true;
+    }
+
+    std::vector<KeyboardDevice> getDetectedKeyboards() {
+        return keyboards;
+    }
+
+    void scanForKeyboards() {
+        // 既存のキーボードはクリアしない（重複を防ぐため）
+        std::cout << "Scanning for keyboards (current count: " << keyboards.size() << ")..." << std::endl;
+
+        // Get current devices
+        CFSetRef devices = IOHIDManagerCopyDevices(hidManager);
+        if (!devices) {
+            std::cout << "No HID devices found" << std::endl;
+            return;
+        }
+
+        CFIndex deviceCount = CFSetGetCount(devices);
+        std::cout << "Found " << deviceCount << " HID devices" << std::endl;
+
+        if (deviceCount > 0) {
+            IOHIDDeviceRef* deviceArray = (IOHIDDeviceRef*)malloc(sizeof(IOHIDDeviceRef) * deviceCount);
+            CFSetGetValues(devices, (const void**)deviceArray);
+
+            for (CFIndex i = 0; i < deviceCount; i++) {
+                IOHIDDeviceRef device = deviceArray[i];
+
+                // 既に追加済みかチェック
+                auto it = deviceToKeyboardMap.find(device);
+                if (it == deviceToKeyboardMap.end()) {
+                    addKeyboard(device);
+                } else {
+                    std::cout << "Device already scanned, skipping..." << std::endl;
+                }
+            }
+
+            free(deviceArray);
+        }
+
+        CFRelease(devices);
+
+        std::cout << "Total keyboards detected: " << keyboards.size() << std::endl;
+    }
+
+    // キー入力イベントコールバック
+    static void inputValueCallback(void* context, IOReturn result, void* sender, IOHIDValueRef value) {
+        KeyboardDetector* detector = static_cast<KeyboardDetector*>(context);
+
+        IOHIDElementRef element = IOHIDValueGetElement(value);
+        IOHIDDeviceRef device = IOHIDElementGetDevice(element);
+
+        auto it = detector->deviceToKeyboardMap.find(device);
+        if (it == detector->deviceToKeyboardMap.end()) {
+            return; // デバイスが見つからない
+        }
+
+        int keyboardIndex = it->second;
+        if (keyboardIndex >= (int)detector->keyboards.size()) {
+            return;
+        }
+
+        uint32_t usagePage = IOHIDElementGetUsagePage(element);
+        uint32_t usage = IOHIDElementGetUsage(element);
+        CFIndex integerValue = IOHIDValueGetIntegerValue(value);
+        uint64_t timestamp = IOHIDValueGetTimeStamp(value);
+
+        // キーボードイベントのみ処理 (usage page 7 = キーボード/キーパッド)
+        if (usagePage == kHIDPage_KeyboardOrKeypad && integerValue > 0) { // キー押下時のみ
+            KeyEvent keyEvent;
+            keyEvent.keyboardId = detector->keyboards[keyboardIndex].keyboardId;
+            keyEvent.usagePage = usagePage;
+            keyEvent.usage = usage;
+            keyEvent.value = (int32_t)integerValue;
+            keyEvent.timestamp = timestamp;
+            keyEvent.keyName = detector->getKeyName(usage);
+
+            // キューに追加
+            {
+                std::lock_guard<std::mutex> lock(detector->queueMutex);
+                detector->keyEventQueue.push(keyEvent);
+            }
+
+            // JavaScriptコールバックがあれば呼び出し
+            if (detector->keyEventCallback) {
+                KeyEvent* eventCopy = new KeyEvent(keyEvent);
+                napi_call_threadsafe_function(detector->keyEventCallback, eventCopy, napi_tsfn_blocking);
+            }
+
+            std::cout << "🎹 Key from KB-" << keyEvent.keyboardId << ": "
+                      << keyEvent.keyName << " (usage: 0x" << std::hex << usage << std::dec << ")" << std::endl;
+        }
+    }
+
+    // HID usage codeからキー名に変換
+    std::string getKeyName(uint32_t usage) {
+        // 基本的なキーのマッピング
+        static const std::map<uint32_t, std::string> keyMap = {
+            {0x04, "a"}, {0x05, "b"}, {0x06, "c"}, {0x07, "d"}, {0x08, "e"}, {0x09, "f"},
+            {0x0A, "g"}, {0x0B, "h"}, {0x0C, "i"}, {0x0D, "j"}, {0x0E, "k"}, {0x0F, "l"},
+            {0x10, "m"}, {0x11, "n"}, {0x12, "o"}, {0x13, "p"}, {0x14, "q"}, {0x15, "r"},
+            {0x16, "s"}, {0x17, "t"}, {0x18, "u"}, {0x19, "v"}, {0x1A, "w"}, {0x1B, "x"},
+            {0x1C, "y"}, {0x1D, "z"},
+            {0x1E, "1"}, {0x1F, "2"}, {0x20, "3"}, {0x21, "4"}, {0x22, "5"},
+            {0x23, "6"}, {0x24, "7"}, {0x25, "8"}, {0x26, "9"}, {0x27, "0"},
+            {0x28, "Enter"}, {0x29, "Escape"}, {0x2A, "Backspace"}, {0x2B, "Tab"},
+            {0x2C, "Space"}, {0x2D, "-"}, {0x2E, "="}, {0x2F, "["}, {0x30, "]"},
+            {0x31, "\\"}, {0x33, ";"}, {0x34, "'"}, {0x35, "`"}, {0x36, ","},
+            {0x37, "."}, {0x38, "/"}, {0x39, "CapsLock"},
+            {0x3A, "F1"}, {0x3B, "F2"}, {0x3C, "F3"}, {0x3D, "F4"}, {0x3E, "F5"},
+            {0x3F, "F6"}, {0x40, "F7"}, {0x41, "F8"}, {0x42, "F9"}, {0x43, "F10"},
+            {0x44, "F11"}, {0x45, "F12"},
+            {0xE0, "LeftCtrl"}, {0xE1, "LeftShift"}, {0xE2, "LeftAlt"}, {0xE3, "LeftCmd"},
+            {0xE4, "RightCtrl"}, {0xE5, "RightShift"}, {0xE6, "RightAlt"}, {0xE7, "RightCmd"}
+        };
+
+        auto it = keyMap.find(usage);
+        if (it != keyMap.end()) {
+            return it->second;
+        }
+        return "Unknown(0x" + std::to_string(usage) + ")";
+    }
+
+private:
+    static void deviceMatchingCallback(void* context, IOReturn result, void* sender, IOHIDDeviceRef device) {
+        KeyboardDetector* detector = static_cast<KeyboardDetector*>(context);
+        std::cout << "Device connected" << std::endl;
+
+        // 既に追加済みかチェック
+        auto it = detector->deviceToKeyboardMap.find(device);
+        if (it != detector->deviceToKeyboardMap.end()) {
+            std::cout << "Device already exists, skipping..." << std::endl;
+            return;
+        }
+
+        detector->addKeyboard(device);
+    }
+
+    static void deviceRemovalCallback(void* context, IOReturn result, void* sender, IOHIDDeviceRef device) {
+        KeyboardDetector* detector = static_cast<KeyboardDetector*>(context);
+        std::cout << "Device disconnected" << std::endl;
+        detector->removeKeyboard(device);
+    }
+
+    void addKeyboard(IOHIDDeviceRef device) {
+        if (!device) return;
+
+        // Get device properties
+        CFStringRef productNameRef = (CFStringRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey));
+        CFStringRef manufacturerRef = (CFStringRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDManufacturerKey));
+        CFNumberRef vendorIdRef = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDVendorIDKey));
+        CFNumberRef productIdRef = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductIDKey));
+        CFNumberRef locationIdRef = (CFNumberRef)IOHIDDeviceGetProperty(device, CFSTR(kIOHIDLocationIDKey));
+
+        KeyboardDevice kbd;
+
+        // Extract product name
+        if (productNameRef) {
+            const char* productName = CFStringGetCStringPtr(productNameRef, kCFStringEncodingUTF8);
+            if (productName) {
+                kbd.name = std::string(productName);
+            } else {
+                char buffer[256];
+                if (CFStringGetCString(productNameRef, buffer, sizeof(buffer), kCFStringEncodingUTF8)) {
+                    kbd.name = std::string(buffer);
+                }
+            }
+        } else {
+            kbd.name = "Unknown Keyboard";
+        }
+
+        // Extract manufacturer
+        if (manufacturerRef) {
+            const char* manufacturer = CFStringGetCStringPtr(manufacturerRef, kCFStringEncodingUTF8);
+            if (manufacturer) {
+                kbd.manufacturer = std::string(manufacturer);
+            } else {
+                char buffer[256];
+                if (CFStringGetCString(manufacturerRef, buffer, sizeof(buffer), kCFStringEncodingUTF8)) {
+                    kbd.manufacturer = std::string(buffer);
+                }
+            }
+        } else {
+            kbd.manufacturer = "Unknown";
+        }
+
+        // Extract vendor and product IDs
+        if (vendorIdRef) {
+            CFNumberGetValue(vendorIdRef, kCFNumberSInt32Type, &kbd.vendorId);
+        }
+
+        if (productIdRef) {
+            CFNumberGetValue(productIdRef, kCFNumberSInt32Type, &kbd.productId);
+        }
+
+        if (locationIdRef) {
+            CFNumberGetValue(locationIdRef, kCFNumberSInt32Type, &kbd.locationId);
+        }
+
+        kbd.device = device;
+
+        // キーボードをリストに追加してからIDを設定
+        keyboards.push_back(kbd);
+        int keyboardIndex = keyboards.size() - 1;
+
+        // キーボードIDは1ベースで設定（kb-1, kb-2, ...）
+        keyboards[keyboardIndex].keyboardId = keyboardIndex + 1;
+
+        // 入力値コールバックを登録
+        IOHIDDeviceRegisterInputValueCallback(device, inputValueCallback, this);
+
+        deviceToKeyboardMap[device] = keyboardIndex;
+
+        std::cout << "Added keyboard: " << kbd.name << " (" << kbd.manufacturer << ")" << std::endl;
+        std::cout << "  Vendor ID: 0x" << std::hex << kbd.vendorId << std::dec << std::endl;
+        std::cout << "  Product ID: 0x" << std::hex << kbd.productId << std::dec << std::endl;
+        std::cout << "  Location ID: 0x" << std::hex << kbd.locationId << std::dec << std::endl;
+    }
+
+    void removeKeyboard(IOHIDDeviceRef device) {
+        auto it = deviceToKeyboardMap.find(device);
+        if (it != deviceToKeyboardMap.end()) {
+            int index = it->second;
+            if (index >= 0 && index < (int)keyboards.size()) {
+                std::cout << "Removed keyboard: " << keyboards[index].name << std::endl;
+                keyboards.erase(keyboards.begin() + index);
+                deviceToKeyboardMap.erase(it);
+
+                // Update remaining indices
+                for (auto& pair : deviceToKeyboardMap) {
+                    if (pair.second > index) {
+                        pair.second--;
+                    }
+                }
+            }
+        }
+    }
+};
+
+static KeyboardDetector* detector = nullptr;
+
+napi_value Initialize(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        detector = new KeyboardDetector();
+    }
+
+    bool success = detector->initialize();
+
+    napi_value result;
+    napi_get_boolean(env, success, &result);
+    return result;
+}
+
+napi_value ScanKeyboards(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        napi_value result;
+        napi_create_array_with_length(env, 0, &result);
+        return result;
+    }
+
+    detector->scanForKeyboards();
+    std::vector<KeyboardDevice> keyboards = detector->getDetectedKeyboards();
+
+    napi_value result;
+    napi_create_array_with_length(env, keyboards.size(), &result);
+
+    for (size_t i = 0; i < keyboards.size(); i++) {
+        napi_value keyboard;
+        napi_create_object(env, &keyboard);
+
+        napi_value name, manufacturer, vendorId, productId, locationId;
+        napi_create_string_utf8(env, keyboards[i].name.c_str(), NAPI_AUTO_LENGTH, &name);
+        napi_create_string_utf8(env, keyboards[i].manufacturer.c_str(), NAPI_AUTO_LENGTH, &manufacturer);
+        napi_create_uint32(env, keyboards[i].vendorId, &vendorId);
+        napi_create_uint32(env, keyboards[i].productId, &productId);
+        napi_create_uint32(env, keyboards[i].locationId, &locationId);
+
+        napi_set_named_property(env, keyboard, "name", name);
+        napi_set_named_property(env, keyboard, "manufacturer", manufacturer);
+        napi_set_named_property(env, keyboard, "vendorId", vendorId);
+        napi_set_named_property(env, keyboard, "productId", productId);
+        napi_set_named_property(env, keyboard, "locationId", locationId);
+
+        napi_set_element(env, result, i, keyboard);
+    }
+
+    return result;
+}
+
+napi_value GetKeyboardCount(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        napi_value result;
+        napi_create_uint32(env, 0, &result);
+        return result;
+    }
+
+    std::vector<KeyboardDevice> keyboards = detector->getDetectedKeyboards();
+
+    napi_value result;
+    napi_create_uint32(env, keyboards.size(), &result);
+    return result;
+}
+
+// キーイベントコールバック用のスレッドセーフ関数コールバック
+void keyEventCallbackJS(napi_env env, napi_value js_callback, void* context, void* data) {
+    KeyEvent* keyEvent = static_cast<KeyEvent*>(data);
+
+    if (env != nullptr) {
+        napi_value undefined, keyEventObj;
+        napi_get_undefined(env, &undefined);
+
+        // KeyEventオブジェクトを作成
+        napi_create_object(env, &keyEventObj);
+
+        napi_value keyboardId, usagePage, usage, value, timestamp, keyName;
+        napi_create_int32(env, keyEvent->keyboardId, &keyboardId);
+        napi_create_uint32(env, keyEvent->usagePage, &usagePage);
+        napi_create_uint32(env, keyEvent->usage, &usage);
+        napi_create_int32(env, keyEvent->value, &value);
+        napi_create_bigint_uint64(env, keyEvent->timestamp, &timestamp);
+        napi_create_string_utf8(env, keyEvent->keyName.c_str(), NAPI_AUTO_LENGTH, &keyName);
+
+        napi_set_named_property(env, keyEventObj, "keyboardId", keyboardId);
+        napi_set_named_property(env, keyEventObj, "usagePage", usagePage);
+        napi_set_named_property(env, keyEventObj, "usage", usage);
+        napi_set_named_property(env, keyEventObj, "value", value);
+        napi_set_named_property(env, keyEventObj, "timestamp", timestamp);
+        napi_set_named_property(env, keyEventObj, "keyName", keyName);
+
+        // コールバックを呼び出し
+        if (js_callback != nullptr) {
+            napi_value global, result;
+            napi_get_global(env, &global);
+            napi_call_function(env, global, js_callback, 1, &keyEventObj, &result);
+        }
+    }
+
+    delete keyEvent;
+}
+
+napi_value SetKeyEventCallback(napi_env env, napi_callback_info info) {
+    size_t argc = 1;
+    napi_value args[1];
+    napi_get_cb_info(env, info, &argc, args, nullptr, nullptr);
+
+    if (argc != 1) {
+        napi_throw_error(env, nullptr, "Expected exactly one argument (callback function)");
+        return nullptr;
+    }
+
+    napi_valuetype valuetype;
+    napi_typeof(env, args[0], &valuetype);
+    if (valuetype != napi_function) {
+        napi_throw_error(env, nullptr, "Expected first argument to be a function");
+        return nullptr;
+    }
+
+    if (!detector) {
+        napi_throw_error(env, nullptr, "Detector not initialized");
+        return nullptr;
+    }
+
+    // 既存のコールバックをクリーンアップ
+    if (detector->keyEventCallback) {
+        napi_release_threadsafe_function(detector->keyEventCallback, napi_tsfn_release);
+    }
+
+    // スレッドセーフ関数を作成
+    napi_value resourceName;
+    napi_create_string_utf8(env, "KeyEventCallback", NAPI_AUTO_LENGTH, &resourceName);
+
+    napi_create_threadsafe_function(
+        env,
+        args[0],
+        nullptr,
+        resourceName,
+        0,
+        1,
+        nullptr,
+        nullptr,
+        nullptr,
+        keyEventCallbackJS,
+        &detector->keyEventCallback
+    );
+
+    napi_value result;
+    napi_get_boolean(env, true, &result);
+    return result;
+}
+
+napi_value GetNextKeyEvent(napi_env env, napi_callback_info info) {
+    if (!detector) {
+        napi_value result;
+        napi_get_null(env, &result);
+        return result;
+    }
+
+    std::lock_guard<std::mutex> lock(detector->queueMutex);
+    if (detector->keyEventQueue.empty()) {
+        napi_value result;
+        napi_get_null(env, &result);
+        return result;
+    }
+
+    KeyEvent keyEvent = detector->keyEventQueue.front();
+    detector->keyEventQueue.pop();
+
+    // KeyEventオブジェクトを作成
+    napi_value keyEventObj;
+    napi_create_object(env, &keyEventObj);
+
+    napi_value keyboardId, usagePage, usage, value, timestamp, keyName;
+    napi_create_int32(env, keyEvent.keyboardId, &keyboardId);
+    napi_create_uint32(env, keyEvent.usagePage, &usagePage);
+    napi_create_uint32(env, keyEvent.usage, &usage);
+    napi_create_int32(env, keyEvent.value, &value);
+    napi_create_bigint_uint64(env, keyEvent.timestamp, &timestamp);
+    napi_create_string_utf8(env, keyEvent.keyName.c_str(), NAPI_AUTO_LENGTH, &keyName);
+
+    napi_set_named_property(env, keyEventObj, "keyboardId", keyboardId);
+    napi_set_named_property(env, keyEventObj, "usagePage", usagePage);
+    napi_set_named_property(env, keyEventObj, "usage", usage);
+    napi_set_named_property(env, keyEventObj, "value", value);
+    napi_set_named_property(env, keyEventObj, "timestamp", timestamp);
+    napi_set_named_property(env, keyEventObj, "keyName", keyName);
+
+    return keyEventObj;
+}
+
+napi_value Init(napi_env env, napi_value exports) {
+    napi_value initializeFn, scanKeyboardsFn, getKeyboardCountFn, setKeyEventCallbackFn, getNextKeyEventFn;
+
+    napi_create_function(env, nullptr, 0, Initialize, nullptr, &initializeFn);
+    napi_create_function(env, nullptr, 0, ScanKeyboards, nullptr, &scanKeyboardsFn);
+    napi_create_function(env, nullptr, 0, GetKeyboardCount, nullptr, &getKeyboardCountFn);
+    napi_create_function(env, nullptr, 0, SetKeyEventCallback, nullptr, &setKeyEventCallbackFn);
+    napi_create_function(env, nullptr, 0, GetNextKeyEvent, nullptr, &getNextKeyEventFn);
+
+    napi_set_named_property(env, exports, "initialize", initializeFn);
+    napi_set_named_property(env, exports, "scanKeyboards", scanKeyboardsFn);
+    napi_set_named_property(env, exports, "getKeyboardCount", getKeyboardCountFn);
+    napi_set_named_property(env, exports, "setKeyEventCallback", setKeyEventCallbackFn);
+    napi_set_named_property(env, exports, "getNextKeyEvent", getNextKeyEventFn);
+
+    return exports;
+}
+
+NAPI_MODULE(keyboard_detector, Init)

--- a/test-electron-keyboard/native-keyboard-addon/test-real-input.js
+++ b/test-electron-keyboard/native-keyboard-addon/test-real-input.js
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+
+const { KeyboardDetector } = require('./index.js');
+
+console.log('=== リアル入力キャプチャテスト ===');
+
+async function runKeyInputTest() {
+    const detector = new KeyboardDetector();
+
+    console.log('\n1. 初期化中...');
+    const initialized = detector.initialize();
+
+    if (!initialized) {
+        console.error('❌ 初期化失敗');
+        process.exit(1);
+    }
+
+    console.log('\n2. キーボード検知中...');
+    const keyboards = detector.scanKeyboards();
+
+    if (keyboards.length === 0) {
+        console.error('❌ キーボードが検知できませんでした');
+        process.exit(1);
+    }
+
+    console.log(`\n✅ ${keyboards.length}個のキーボードを検知:`);
+    keyboards.forEach((kb, i) => {
+        console.log(`  KB-${i + 1}: ${kb.name} (${kb.manufacturer})`);
+    });
+
+    console.log('\n3. 個別キー入力監視開始...');
+    console.log('💡 各キーボードで文字を入力してください (10秒間)');
+    console.log('💡 Ctrl+C で終了');
+
+    // コールバック方式
+    detector.setKeyEventCallback((keyEvent) => {
+        console.log(`🎹 KB-${keyEvent.keyboardId}: "${keyEvent.keyName}" (usage: 0x${keyEvent.usage.toString(16)})`);
+    });
+
+    // テスト期間
+    setTimeout(() => {
+        console.log('\n4. 10秒経過しました。手動テストが続行できます。');
+    }, 10000);
+
+    // SIGINT (Ctrl+C) ハンドラ
+    process.on('SIGINT', () => {
+        console.log('\n\n=== テスト終了 ===');
+        console.log('✅ 個別キーボード入力キャプチャが動作しました！');
+        process.exit(0);
+    });
+}
+
+// エラーハンドリング
+process.on('uncaughtException', (error) => {
+    console.error('\n❌ エラー:', error.message);
+    process.exit(1);
+});
+
+runKeyInputTest().catch((error) => {
+    console.error('\n❌ テスト失敗:', error.message);
+    process.exit(1);
+});

--- a/test-electron-keyboard/native-keyboard-addon/test.js
+++ b/test-electron-keyboard/native-keyboard-addon/test.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+const { KeyboardDetector } = require('./index.js');
+
+console.log('=== Native Keyboard Detection Test ===');
+
+async function runTest() {
+    const detector = new KeyboardDetector();
+
+    console.log('\n1. Testing initialization...');
+    const initialized = detector.initialize();
+
+    if (!initialized) {
+        console.error('❌ Failed to initialize keyboard detector');
+        console.error('This might be due to:');
+        console.error('  1. Missing permissions (Input Monitoring)');
+        console.error('  2. macOS security restrictions');
+        console.error('  3. Native addon build issues');
+        process.exit(1);
+    }
+
+    console.log('✅ Keyboard detector initialized successfully');
+
+    console.log('\n2. Testing keyboard scan...');
+    const keyboards = detector.scanKeyboards();
+
+    console.log(`\n3. Results:`);
+    console.log(`   Found ${keyboards.length} keyboard(s)`);
+
+    if (keyboards.length === 0) {
+        console.log('\n⚠️ No keyboards detected. This could be due to:');
+        console.log('   1. macOS security restrictions (Input Monitoring permission)');
+        console.log('   2. Missing entitlements in the application');
+        console.log('   3. IOHIDManager configuration issues');
+
+        console.log('\n🔧 Debugging steps:');
+        console.log('   1. Check System Preferences > Security & Privacy > Input Monitoring');
+        console.log('   2. Ensure Terminal or your app has permission');
+        console.log('   3. Try running with sudo (for testing only)');
+        console.log('   4. Connect an external USB keyboard for testing');
+    } else {
+        console.log('\n✅ Keyboards detected successfully:');
+        keyboards.forEach((kbd, index) => {
+            console.log(`\nKeyboard ${index + 1}:`);
+            console.log(`  📱 Name: ${kbd.name}`);
+            console.log(`  🏭 Manufacturer: ${kbd.manufacturer}`);
+            console.log(`  🔢 Vendor ID: 0x${kbd.vendorId.toString(16).toUpperCase()}`);
+            console.log(`  🆔 Product ID: 0x${kbd.productId.toString(16).toUpperCase()}`);
+            console.log(`  📍 Location ID: 0x${kbd.locationId.toString(16).toUpperCase()}`);
+        });
+    }
+
+    console.log('\n4. Testing keyboard count...');
+    const count = detector.getKeyboardCount();
+    console.log(`   Count verification: ${count}`);
+
+    console.log('\n=== Test Complete ===');
+
+    if (keyboards.length > 0) {
+        console.log('🎉 Success! Multiple keyboard detection is working.');
+    } else {
+        console.log('⚠️ No keyboards detected. Check permissions and setup.');
+    }
+}
+
+// Handle errors gracefully
+process.on('uncaughtException', (error) => {
+    console.error('\n❌ Uncaught Exception:', error.message);
+    console.error('Stack trace:', error.stack);
+    process.exit(1);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+    console.error('\n❌ Unhandled Rejection at:', promise, 'reason:', reason);
+    process.exit(1);
+});
+
+// Run the test
+runTest().catch((error) => {
+    console.error('\n❌ Test failed:', error.message);
+    console.error(error.stack);
+    process.exit(1);
+});

--- a/test-electron-keyboard/package-lock.json
+++ b/test-electron-keyboard/package-lock.json
@@ -1,0 +1,2377 @@
+{
+  "name": "test-electron-keyboard",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-electron-keyboard",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp": "^11.4.2",
+        "node-hid": "^2.1.2"
+      },
+      "devDependencies": {
+        "electron": "^26.2.1"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
+      "license": "ISC",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.1",
+        "lru-cache": "^10.0.1",
+        "socks-proxy-agent": "^8.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+      "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.19.124",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.124.tgz",
+      "integrity": "sha512-hY4YWZFLs3ku6D2Gqo3RchTd9VRCcrjqp/I0mmohYeUVA5Y8eCXKJEasHxLAJVZRJuQogfd1GiJ9lgogBgKeuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^4.0.0",
+        "fs-minipass": "^3.0.0",
+        "glob": "^10.2.2",
+        "lru-cache": "^10.0.1",
+        "minipass": "^7.0.3",
+        "minipass-collect": "^2.0.1",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cross-spawn/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/cross-spawn/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+      "integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/electron": {
+      "version": "26.6.10",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-26.6.10.tgz",
+      "integrity": "sha512-pV2SD0RXzAiNRb/2yZrsVmVkBOMrf+DVsPulIgRjlL0+My9BL5spFuhHVMQO9yHl9tFpWtuRpQv0ofM/i9P8xg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^18.11.18",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^4.0.0",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^1.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "ssri": "^12.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+      "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.3",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^3.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
+      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-flush/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-pipeline/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.77.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+      "integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.4.2.tgz",
+      "integrity": "sha512-3gD+6zsrLQH7DyYOUIutaauuXrcyxeTPyQuZQCQoNPZMHMMS5m4y0xclNpvYzoK3VNzuyxT6eF4mkIL4WSZ1eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "tar": "^7.4.3",
+        "tinyglobby": "^0.2.12",
+        "which": "^5.0.0"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-hid": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-hid/-/node-hid-2.2.0.tgz",
+      "integrity": "sha512-vj48zh9j555DZzUhMc8tk/qw6xPFrDyPBH1ST1Z/hWaA/juBJw7IuSxPeOgpzNFNU36mGYj+THioRMt1xOdm/g==",
+      "hasInstallScript": true,
+      "license": "(MIT OR X11)",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^3.0.2",
+        "prebuild-install": "^7.1.1"
+      },
+      "bin": {
+        "hid-showdevices": "src/show-devices.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^3.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/proc-log": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.0.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ssri": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+      "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+      "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^3.1.1"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/test-electron-keyboard/package.json
+++ b/test-electron-keyboard/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "test-electron-keyboard",
+  "version": "1.0.0",
+  "description": "Minimal Electron app to test multiple keyboard input handling",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "dev": "electron . --dev"
+  },
+  "devDependencies": {
+    "electron": "^26.2.1"
+  },
+  "dependencies": {
+    "node-gyp": "^11.4.2",
+    "node-hid": "^2.1.2"
+  },
+  "author": "Takatomo Ezo",
+  "license": "MIT"
+}

--- a/test-electron-keyboard/preload.js
+++ b/test-electron-keyboard/preload.js
@@ -1,0 +1,31 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+// セキュアなAPIをレンダラープロセスに公開
+contextBridge.exposeInMainWorld('electronAPI', {
+    // キーボード情報の取得
+    getKeyboards: () => ipcRenderer.invoke('get-keyboards'),
+    
+    // 入力履歴の取得
+    getInputHistory: () => ipcRenderer.invoke('get-input-history'),
+    
+    // 履歴のクリア
+    clearHistory: () => ipcRenderer.invoke('clear-history'),
+    
+    // イベントリスナー
+    onKeyboardsDetected: (callback) => {
+        ipcRenderer.on('keyboards-detected', (event, keyboards) => {
+            callback(keyboards);
+        });
+    },
+    
+    onKeyInput: (callback) => {
+        ipcRenderer.on('key-input', (event, keyEvent) => {
+            callback(keyEvent);
+        });
+    },
+    
+    // イベントリスナーの削除
+    removeAllListeners: (channel) => {
+        ipcRenderer.removeAllListeners(channel);
+    }
+});

--- a/test-electron-keyboard/renderer.js
+++ b/test-electron-keyboard/renderer.js
@@ -1,0 +1,231 @@
+class KeyboardInputTester {
+    constructor() {
+        this.keyboards = [];
+        this.inputHistory = [];
+        this.isPaused = false;
+        this.keyboardActivity = new Map(); // 各キーボードの最新入力を追跡
+        
+        this.init();
+    }
+
+    async init() {
+        console.log('レンダラー初期化開始');
+        
+        // イベントリスナー設定
+        window.electronAPI.onKeyboardsDetected((keyboards) => {
+            this.handleKeyboardsDetected(keyboards);
+        });
+        
+        window.electronAPI.onKeyInput((keyEvent) => {
+            if (!this.isPaused) {
+                this.handleKeyInput(keyEvent);
+            }
+        });
+        
+        // 初期キーボード情報の取得
+        try {
+            this.keyboards = await window.electronAPI.getKeyboards();
+            this.displayKeyboards();
+            this.updateStatus(`${this.keyboards.length}個のキーボードを検知`);
+        } catch (error) {
+            console.error('キーボード情報取得エラー:', error);
+            this.updateStatus('エラー: キーボード情報を取得できませんでした');
+        }
+        
+        // 既存の履歴があれば取得
+        try {
+            this.inputHistory = await window.electronAPI.getInputHistory();
+            this.displayInputHistory();
+        } catch (error) {
+            console.error('履歴取得エラー:', error);
+        }
+    }
+
+    handleKeyboardsDetected(keyboards) {
+        console.log('キーボード検知:', keyboards);
+        this.keyboards = keyboards;
+        this.displayKeyboards();
+        this.updateStatus(`${keyboards.length}個のキーボードを検知しました`);
+    }
+
+    handleKeyInput(keyEvent) {
+        console.log('キー入力:', keyEvent);
+        
+        // 履歴に追加
+        this.inputHistory.push(keyEvent);
+        if (this.inputHistory.length > 200) {
+            this.inputHistory.shift(); // 古い履歴を削除
+        }
+        
+        // キーボード活動を更新
+        this.keyboardActivity.set(keyEvent.keyboardId, {
+            lastKey: keyEvent.key,
+            timestamp: keyEvent.timestamp,
+            count: (this.keyboardActivity.get(keyEvent.keyboardId)?.count || 0) + 1
+        });
+        
+        // UI更新
+        this.displayInputLog(keyEvent);
+        this.updateKeyboardCards();
+    }
+
+    displayKeyboards() {
+        const infoDiv = document.getElementById('keyboards-info');
+        const gridDiv = document.getElementById('keyboards-grid');
+        
+        if (this.keyboards.length === 0) {
+            infoDiv.textContent = 'キーボードが検知されませんでした';
+            gridDiv.innerHTML = '';
+            return;
+        }
+        
+        infoDiv.textContent = `${this.keyboards.length}個のキーボードが利用可能です:`;
+        
+        gridDiv.innerHTML = this.keyboards.map(keyboard => `
+            <div class="keyboard-card" id="keyboard-${keyboard.id}">
+                <div class="keyboard-name">${keyboard.name}</div>
+                <div class="keyboard-info">
+                    ID: ${keyboard.id} | 検知方法: ${keyboard.method}
+                    ${keyboard.vendorId ? `<br>VendorID: ${keyboard.vendorId} | ProductID: ${keyboard.productId}` : ''}
+                </div>
+                <div class="keyboard-activity" id="activity-${keyboard.id}">
+                    入力待機中...
+                </div>
+            </div>
+        `).join('');
+    }
+
+    updateKeyboardCards() {
+        this.keyboards.forEach(keyboard => {
+            const card = document.getElementById(`keyboard-${keyboard.id}`);
+            const activityDiv = document.getElementById(`activity-${keyboard.id}`);
+            
+            if (card && activityDiv) {
+                const activity = this.keyboardActivity.get(keyboard.id);
+                
+                if (activity) {
+                    // アクティブなキーボードをハイライト
+                    const timeDiff = Date.now() - activity.timestamp;
+                    if (timeDiff < 2000) { // 2秒以内の入力
+                        card.classList.add('active');
+                        setTimeout(() => card.classList.remove('active'), 2000);
+                    }
+                    
+                    // 活動情報を表示
+                    activityDiv.innerHTML = `
+                        最新キー: <span class="key-display">${activity.lastKey}</span><br>
+                        入力数: ${activity.count}<br>
+                        <span class="timestamp">${new Date(activity.timestamp).toLocaleTimeString()}</span>
+                    `;
+                } else {
+                    activityDiv.textContent = '入力待機中...';
+                }
+            }
+        });
+    }
+
+    displayInputLog(keyEvent) {
+        const logDiv = document.getElementById('input-log');
+        const timestamp = new Date(keyEvent.timestamp).toLocaleTimeString();
+        
+        // キーの表示形式を調整
+        let keyDisplay = keyEvent.key;
+        if (keyEvent.key === ' ') keyDisplay = 'Space';
+        if (keyEvent.key === 'Enter') keyDisplay = '⏎';
+        if (keyEvent.key === 'Backspace') keyDisplay = '⌫';
+        if (keyEvent.key === 'Tab') keyDisplay = '⇥';
+        
+        // 修飾キーの表示
+        let modifiers = '';
+        if (keyEvent.modifiers.control) modifiers += 'Ctrl+';
+        if (keyEvent.modifiers.shift) modifiers += 'Shift+';
+        if (keyEvent.modifiers.alt) modifiers += 'Alt+';
+        if (keyEvent.modifiers.meta) modifiers += 'Cmd+';
+        
+        const logEntry = `[${timestamp}] ${keyEvent.keyboardId}: ${modifiers}${keyDisplay}\n`;
+        
+        logDiv.textContent += logEntry;
+        logDiv.scrollTop = logDiv.scrollHeight; // 自動スクロール
+    }
+
+    displayInputHistory() {
+        const logDiv = document.getElementById('input-log');
+        logDiv.textContent = '=== 入力履歴復元 ===\n';
+        
+        this.inputHistory.forEach(keyEvent => {
+            this.displayInputLog(keyEvent);
+        });
+        
+        logDiv.textContent += '\n=== リアルタイム監視開始 ===\n';
+    }
+
+    updateStatus(message) {
+        const statusDiv = document.getElementById('status');
+        statusDiv.textContent = message;
+    }
+    
+    // グローバル関数（HTMLから呼ばれる）
+    async clearLog() {
+        try {
+            await window.electronAPI.clearHistory();
+            this.inputHistory = [];
+            this.keyboardActivity.clear();
+            
+            document.getElementById('input-log').textContent = '=== ログクリア完了 ===\nキーボードで何かタイピングしてください...\n\n';
+            this.updateKeyboardCards();
+            this.updateStatus('ログをクリアしました');
+        } catch (error) {
+            console.error('ログクリアエラー:', error);
+            this.updateStatus('エラー: ログをクリアできませんでした');
+        }
+    }
+    
+    togglePause() {
+        this.isPaused = !this.isPaused;
+        const btn = document.getElementById('pauseBtn');
+        btn.textContent = this.isPaused ? '再開' : '一時停止';
+        
+        const status = this.isPaused ? '入力監視を一時停止中' : '入力監視中';
+        this.updateStatus(status);
+    }
+    
+    exportLog() {
+        const logContent = this.inputHistory.map(event => {
+            const timestamp = new Date(event.timestamp).toISOString();
+            return `${timestamp},${event.keyboardId},${event.key},${event.code}`;
+        }).join('\n');
+        
+        const blob = new Blob(['timestamp,keyboardId,key,code\n' + logContent], 
+                             { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `keyboard-input-log-${new Date().toISOString().slice(0,19)}.csv`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        
+        this.updateStatus('ログをエクスポートしました');
+    }
+}
+
+// グローバル関数を定義（HTMLのonclickから呼ばれる）
+let tester;
+
+window.addEventListener('DOMContentLoaded', () => {
+    tester = new KeyboardInputTester();
+});
+
+function clearLog() {
+    if (tester) tester.clearLog();
+}
+
+function togglePause() {
+    if (tester) tester.togglePause();
+}
+
+function exportLog() {
+    if (tester) tester.exportLog();
+}

--- a/words.js
+++ b/words.js
@@ -1,0 +1,228 @@
+// 保育園児向けタイピングゲーム用単語データベース
+// ひらがな → ローマ字変換
+
+const WORD_SETS = {
+    // やさしい（ひらがな 2-3文字）
+    easy: [
+        { hiragana: 'あり', romaji: 'ari', meaning: '虫の名前' },
+        { hiragana: 'いか', romaji: 'ika', meaning: '海の生き物' },
+        { hiragana: 'うし', romaji: 'usi', meaning: 'ミルクを出す動物' },
+        { hiragana: 'えび', romaji: 'ebi', meaning: '赤い海の生き物' },
+        { hiragana: 'おに', romaji: 'oni', meaning: '角がある怖いもの' },
+        { hiragana: 'かに', romaji: 'kani', meaning: 'はさみがある生き物' },
+        { hiragana: 'きつね', romaji: 'kitune', meaning: 'しっぽがふわふわの動物' },
+        { hiragana: 'くま', romaji: 'kuma', meaning: '大きな森の動物' },
+        { hiragana: 'けむし', romaji: 'kemusi', meaning: 'ちょうちょになる虫' },
+        { hiragana: 'こい', romaji: 'koi', meaning: '池にいる魚' },
+        { hiragana: 'さる', romaji: 'saru', meaning: '木登りが得意な動物' },
+        { hiragana: 'しか', romaji: 'sika', meaning: '角がある優しい動物' },
+        { hiragana: 'すし', romaji: 'susi', meaning: '日本の美味しい料理' },
+        { hiragana: 'せみ', romaji: 'semi', meaning: '夏に鳴く虫' },
+        { hiragana: 'そら', romaji: 'sora', meaning: '青くて高いところ' },
+        { hiragana: 'たこ', romaji: 'tako', meaning: '8本足の海の生き物' },
+        { hiragana: 'ちょう', romaji: 'tyou', meaning: 'きれいな羽の虫' },
+        { hiragana: 'つき', romaji: 'tuki', meaning: '夜に見える丸いもの' },
+        { hiragana: 'てんとう', romaji: 'tentou', meaning: '赤い背中の虫' },
+        { hiragana: 'とり', romaji: 'tori', meaning: '空を飛ぶ動物' },
+        { hiragana: 'なす', romaji: 'nasu', meaning: '紫色の野菜' },
+        { hiragana: 'にじ', romaji: 'niji', meaning: '雨上がりに見える色とりどり' },
+        { hiragana: 'ぬいぐるみ', romaji: 'nuigurumi', meaning: 'ふわふわのおもちゃ' },
+        { hiragana: 'ねこ', romaji: 'neko', meaning: 'にゃんと鳴く動物' },
+        { hiragana: 'のみ', romaji: 'nomi', meaning: '小さな虫' },
+        { hiragana: 'はち', romaji: 'hati', meaning: '蜂蜜を作る虫' },
+        { hiragana: 'ひよこ', romaji: 'hiyoko', meaning: '黄色い鳥の赤ちゃん' },
+        { hiragana: 'ふね', romaji: 'hune', meaning: '水に浮かぶ乗り物' },
+        { hiragana: 'へび', romaji: 'hebi', meaning: '長い体の動物' },
+        { hiragana: 'ほし', romaji: 'hosi', meaning: '夜空に光るもの' },
+        { hiragana: 'まめ', romaji: 'mame', meaning: '小さな食べ物' },
+        { hiragana: 'みず', romaji: 'mizu', meaning: '透明で飲むもの' },
+        { hiragana: 'むし', romaji: 'musi', meaning: '小さな生き物' },
+        { hiragana: 'めだか', romaji: 'medaka', meaning: '小さな魚' },
+        { hiragana: 'もち', romaji: 'moti', meaning: 'お正月に食べるもの' },
+        { hiragana: 'やぎ', romaji: 'yagi', meaning: '角がある白い動物' },
+        { hiragana: 'ゆき', romaji: 'yuki', meaning: '冬に降る白いもの' },
+        { hiragana: 'よつば', romaji: 'yotuba', meaning: '四つの葉っぱ' },
+        { hiragana: 'らっこ', romaji: 'rakko', meaning: '背泳ぎする動物' },
+        { hiragana: 'りす', romaji: 'risu', meaning: 'どんぐりが好きな動物' },
+        { hiragana: 'るり', romaji: 'ruri', meaning: '青い鳥' },
+        { hiragana: 'れもん', romaji: 'remon', meaning: '黄色い酸っぱい果物' },
+        { hiragana: 'ろば', romaji: 'roba', meaning: '耳が長い動物' },
+    ],
+
+    // ふつう（ひらがな 4-5文字）
+    normal: [
+        { hiragana: 'あひる', romaji: 'ahiru', meaning: '水鳥の仲間' },
+        { hiragana: 'いちご', romaji: 'itigo', meaning: '赤くて甘い果物' },
+        { hiragana: 'うさぎ', romaji: 'usagi', meaning: '耳が長い動物' },
+        { hiragana: 'えんぴつ', romaji: 'enpitu', meaning: '字を書く道具' },
+        { hiragana: 'おもちゃ', romaji: 'omotya', meaning: '遊ぶための道具' },
+        { hiragana: 'かぶとむし', romaji: 'kabutomusi', meaning: '角がある強い虫' },
+        { hiragana: 'きりん', romaji: 'kirin', meaning: '首が長い動物' },
+        { hiragana: 'くじら', romaji: 'kujira', meaning: '海で一番大きな動物' },
+        { hiragana: 'けーき', romaji: 'ke-ki', meaning: '誕生日に食べる甘いもの' },
+        { hiragana: 'こあら', romaji: 'koara', meaning: 'ユーカリを食べる動物' },
+        { hiragana: 'さかな', romaji: 'sakana', meaning: '水の中で泳ぐ生き物' },
+        { hiragana: 'しまうま', romaji: 'simauma', meaning: '白と黒のしま模様の動物' },
+        { hiragana: 'すいか', romaji: 'suika', meaning: '夏の大きな果物' },
+        { hiragana: 'せんせい', romaji: 'sensei', meaning: '教えてくれる人' },
+        { hiragana: 'そふと', romaji: 'sohuto', meaning: 'やわらかいもの' },
+        { hiragana: 'たまご', romaji: 'tamago', meaning: 'ひよこが生まれるもの' },
+        { hiragana: 'ちゅーりっぷ', romaji: 'tyu-rippu', meaning: '春に咲く花' },
+        { hiragana: 'つくえ', romaji: 'tukue', meaning: '勉強する時に使う家具' },
+        { hiragana: 'てれび', romaji: 'telebi', meaning: '番組を見る機械' },
+        { hiragana: 'とまと', romaji: 'tomato', meaning: '赤い野菜' },
+        { hiragana: 'なっとう', romaji: 'nattou', meaning: 'ねばねばした食べ物' },
+        { hiragana: 'にんじん', romaji: 'ninjin', meaning: 'オレンジ色の野菜' },
+        { hiragana: 'ぬりえ', romaji: 'nurie', meaning: '色を塗って遊ぶもの' },
+        { hiragana: 'ねずみ', romaji: 'nezumi', meaning: 'チーズが好きな小さな動物' },
+        { hiragana: 'のりもの', romaji: 'norimono', meaning: '乗って移動するもの' },
+        { hiragana: 'はんばーが', romaji: 'hanba-ga', meaning: 'パンに挟んだ料理' },
+        { hiragana: 'ひまわり', romaji: 'himawari', meaning: '大きな黄色い花' },
+        { hiragana: 'ふうせん', romaji: 'huusen', meaning: '空に飛ぶ丸いもの' },
+        { hiragana: 'へりこぷた', romaji: 'herikoputa', meaning: 'プロペラで飛ぶ乗り物' },
+        { hiragana: 'ほたる', romaji: 'hotaru', meaning: '光る虫' },
+        { hiragana: 'みかん', romaji: 'mikan', meaning: 'オレンジ色の果物' },
+        { hiragana: 'むかで', romaji: 'mukade', meaning: '足がたくさんある虫' },
+        { hiragana: 'めろん', romaji: 'meron', meaning: '緑色の甘い果物' },
+        { hiragana: 'もんしろ', romaji: 'monsiro', meaning: '白いちょうちょ' },
+        { hiragana: 'やさい', romaji: 'yasai', meaning: '体に良い食べ物' },
+        { hiragana: 'ゆうびん', romaji: 'yuubin', meaning: '手紙を届けるサービス' },
+        { hiragana: 'よっと', romaji: 'yotto', meaning: '風で進む小さな船' },
+        { hiragana: 'らいおん', romaji: 'raion', meaning: '百獣の王' },
+        { hiragana: 'りんご', romaji: 'ringo', meaning: '赤い果物' },
+        { hiragana: 'るーる', romaji: 'ru-ru', meaning: '決まりや約束' },
+        { hiragana: 'れっしゃ', romaji: 'ressya', meaning: '線路を走る乗り物' },
+        { hiragana: 'ろけっと', romaji: 'roketto', meaning: '宇宙に飛ぶ乗り物' },
+    ],
+
+    // むずかしい（ひらがな 6文字以上）
+    hard: [
+        { hiragana: 'あまがえる', romaji: 'amagaeru', meaning: '雨に鳴くかえる' },
+        { hiragana: 'いるか', romaji: 'iruka', meaning: '海で賢い動物' },
+        { hiragana: 'うみがめ', romaji: 'umigame', meaning: '海にいる大きなかめ' },
+        { hiragana: 'えれべーた', romaji: 'erebe-ta', meaning: '上下に動く部屋' },
+        { hiragana: 'おーけすとら', romaji: 'o-kesutora', meaning: 'たくさんの楽器で演奏' },
+        { hiragana: 'かんがるー', romaji: 'kangaru-', meaning: '袋を持つ動物' },
+        { hiragana: 'きりぎりす', romaji: 'kirigrisu', meaning: '鳴き声がきれいな虫' },
+        { hiragana: 'くりすます', romaji: 'kurisumasu', meaning: '12月の楽しい日' },
+        { hiragana: 'けーきやさん', romaji: 'ke-kiyasan', meaning: 'ケーキを作る人' },
+        { hiragana: 'こんぴゅーた', romaji: 'konpyuta', meaning: 'いろいろできる機械' },
+        { hiragana: 'さんどいっち', romaji: 'sandoitti', meaning: 'パンに挟んだ食べ物' },
+        { hiragana: 'しゃぼんだま', romaji: 'syabondama', meaning: '石鹸でできる泡' },
+        { hiragana: 'すぱげってぃ', romaji: 'supagetti', meaning: '長い麺の料理' },
+        { hiragana: 'せーたー', romaji: 'se-ta-', meaning: '毛糸で作った服' },
+        { hiragana: 'そふとくりーむ', romaji: 'sohutokuri-mu', meaning: '冷たくて甘いおやつ' },
+        { hiragana: 'たんぽぽ', romaji: 'tanpopo', meaning: '黄色い綿毛の花' },
+        { hiragana: 'ちんぱんじー', romaji: 'tinpanji-', meaning: '人に似た動物' },
+        { hiragana: 'つりばり', romaji: 'turibari', meaning: '魚を釣る道具' },
+        { hiragana: 'てんとうむし', romaji: 'tentoumusi', meaning: '赤い背中に黒い点の虫' },
+        { hiragana: 'とらんぽりん', romaji: 'toranporin', meaning: '跳ねて遊ぶ道具' },
+        { hiragana: 'なべりょうり', romaji: 'naberyouri', meaning: '鍋で作る温かい料理' },
+        { hiragana: 'にじのはし', romaji: 'nijinohasi', meaning: '虹がかかる橋' },
+        { hiragana: 'ぬいぐるみやさん', romaji: 'nuigurumiyasan', meaning: 'ぬいぐるみを売る店' },
+        { hiragana: 'ねずみのすみか', romaji: 'nezuminosumika', meaning: 'ねずみが住む場所' },
+        { hiragana: 'のぞみでんしゃ', romaji: 'nozomidensya', meaning: '早く走る電車' },
+        { hiragana: 'はんばーがーやさん', romaji: 'hanba-ga-yasan', meaning: 'ハンバーガーを売る店' },
+        { hiragana: 'ひこうき', romaji: 'hikouki', meaning: '空を飛ぶ乗り物' },
+        { hiragana: 'ふらいぱん', romaji: 'huraipan', meaning: '料理を作る道具' },
+        { hiragana: 'へりこぷたー', romaji: 'herikoputar', meaning: '回るはねで飛ぶ乗り物' },
+        { hiragana: 'ほっとけーき', romaji: 'hottoke-ki', meaning: 'ふわふわの甘いもの' },
+        { hiragana: 'ままごとあそび', romaji: 'mamagotoasobi', meaning: 'おうちごっこの遊び' },
+        { hiragana: 'みずようかん', romaji: 'mizuyoukan', meaning: '夏の和菓子' },
+        { hiragana: 'むしとりあみ', romaji: 'musitorami', meaning: '虫を捕まえる道具' },
+        { hiragana: 'めがねざる', romaji: 'meganezaru', meaning: 'めがねをかけたような顔の猿' },
+        { hiragana: 'もーにんぐ', romaji: 'mo-ningu', meaning: '朝の時間' },
+        { hiragana: 'やきゅうぼーる', romaji: 'yakyubo-ru', meaning: '野球で使うボール' },
+        { hiragana: 'ゆめのくに', romaji: 'yumenokuni', meaning: '寝ている時に見る世界' },
+        { hiragana: 'よーぐると', romaji: 'yo-guruto', meaning: '酸っぱくて体に良い食べ物' },
+        { hiragana: 'らじおたいそう', romaji: 'rajiotaisou', meaning: 'ラジオに合わせて体を動かす' },
+        { hiragana: 'りもこんからー', romaji: 'rimokonkara-', meaning: '遠くから動かす道具' },
+        { hiragana: 'るーれっと', romaji: 'ru-retto', meaning: '回して遊ぶゲーム' },
+        { hiragana: 'れいぞうこ', romaji: 'reizouko', meaning: '食べ物を冷やす機械' },
+        { hiragana: 'ろーらーすけーと', romaji: 'ro-ra-suke-to', meaning: 'ローラーで滑る靴' },
+    ]
+};
+
+// 単語セットを取得する関数
+function getWordSet(difficulty) {
+    const validDifficulties = ['easy', 'normal', 'hard'];
+    if (!validDifficulties.includes(difficulty)) {
+        console.warn(`無効な難易度: ${difficulty}. "easy"を使用します。`);
+        difficulty = 'easy';
+    }
+    return WORD_SETS[difficulty];
+}
+
+// ランダムに単語を取得する関数
+function getRandomWord(difficulty) {
+    const wordSet = getWordSet(difficulty);
+    const randomIndex = Math.floor(Math.random() * wordSet.length);
+    return wordSet[randomIndex];
+}
+
+// 指定数の単語をランダムに取得する関数（重複なし）
+function getRandomWords(difficulty, count) {
+    const wordSet = getWordSet(difficulty);
+    const shuffled = [...wordSet].sort(() => 0.5 - Math.random());
+    return shuffled.slice(0, Math.min(count, wordSet.length));
+}
+
+// ローマ字をひらがなに変換するためのマッピング
+const ROMAJI_TO_HIRAGANA = {
+    'a': 'あ', 'i': 'い', 'u': 'う', 'e': 'え', 'o': 'お',
+    'ka': 'か', 'ki': 'き', 'ku': 'く', 'ke': 'け', 'ko': 'こ',
+    'ga': 'が', 'gi': 'ぎ', 'gu': 'ぐ', 'ge': 'げ', 'go': 'ご',
+    'sa': 'さ', 'si': 'し', 'su': 'す', 'se': 'せ', 'so': 'そ',
+    'za': 'ざ', 'zi': 'じ', 'zu': 'ず', 'ze': 'ぜ', 'zo': 'ぞ',
+    'ta': 'た', 'ti': 'ち', 'tu': 'つ', 'te': 'て', 'to': 'と',
+    'da': 'だ', 'di': 'ぢ', 'du': 'づ', 'de': 'で', 'do': 'ど',
+    'na': 'な', 'ni': 'に', 'nu': 'ぬ', 'ne': 'ね', 'no': 'の',
+    'ha': 'は', 'hi': 'ひ', 'hu': 'ふ', 'he': 'へ', 'ho': 'ほ',
+    'ba': 'ば', 'bi': 'び', 'bu': 'ぶ', 'be': 'べ', 'bo': 'ぼ',
+    'pa': 'ぱ', 'pi': 'ぴ', 'pu': 'ぷ', 'pe': 'ぺ', 'po': 'ぽ',
+    'ma': 'ま', 'mi': 'み', 'mu': 'む', 'me': 'め', 'mo': 'も',
+    'ya': 'や', 'yu': 'ゆ', 'yo': 'よ',
+    'ra': 'ら', 'ri': 'り', 'ru': 'る', 're': 'れ', 'ro': 'ろ',
+    'wa': 'わ', 'wo': 'を', 'n': 'ん',
+    // 濁音・半濁音・拗音も追加可能
+    'kya': 'きゃ', 'kyu': 'きゅ', 'kyo': 'きょ',
+    'sha': 'しゃ', 'shu': 'しゅ', 'sho': 'しょ',
+    'cha': 'ちゃ', 'chu': 'ちゅ', 'cho': 'ちょ',
+    'nya': 'にゃ', 'nyu': 'にゅ', 'nyo': 'にょ',
+    'hya': 'ひゃ', 'hyu': 'ひゅ', 'hyo': 'ひょ',
+    'mya': 'みゃ', 'myu': 'みゅ', 'myo': 'みょ',
+    'rya': 'りゃ', 'ryu': 'りゅ', 'ryo': 'りょ'
+};
+
+// 難易度別の統計情報
+function getWordSetStats() {
+    return {
+        easy: {
+            count: WORD_SETS.easy.length,
+            avgLength: (WORD_SETS.easy.reduce((sum, word) => sum + word.hiragana.length, 0) / WORD_SETS.easy.length).toFixed(1),
+            description: '2-3文字のひらがな'
+        },
+        normal: {
+            count: WORD_SETS.normal.length,
+            avgLength: (WORD_SETS.normal.reduce((sum, word) => sum + word.hiragana.length, 0) / WORD_SETS.normal.length).toFixed(1),
+            description: '4-5文字のひらがな'
+        },
+        hard: {
+            count: WORD_SETS.hard.length,
+            avgLength: (WORD_SETS.hard.reduce((sum, word) => sum + word.hiragana.length, 0) / WORD_SETS.hard.length).toFixed(1),
+            description: '6文字以上のひらがな'
+        }
+    };
+}
+
+// モジュールエクスポート（Node.js環境用）
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        WORD_SETS,
+        getWordSet,
+        getRandomWord,
+        getRandomWords,
+        getWordSetStats,
+        ROMAJI_TO_HIRAGANA
+    };
+}


### PR DESCRIPTION
このPRは、開発用プリセット適用時にセットアップを自動で進め、ゲーム開始直前の画面まで遷移する機能を追加します。

主な変更点
- applyDevPreset から advanceToPreGame を呼び出し、自動で 1.2→1.6 を進行
- プレイヤー集合 → チーム自動作成 → ターン順自動決定 → キーボード自動割り当て → お題数設定 まで自動化
- プリセットの難易度/ゲーム時間から難易度と目標数を推定して設定
- キーボード不足時は 1.5 で停止し、手動調整に切り替え
- 進行ログ/ステータス更新を追加して状況を可視化

確認方法
1. アプリ起動（npm run dev）
2. 画面上部の「⚡ 開発プリセット」で任意のプリセットを選択 → 「🚀 プリセット適用」
3. 自動でセットアップが進行し、ゲーム開始直前の画面が表示されること
4. そのまま「ゲーム開始！」で開始できること

備考
- 自動進行は「検知キーボード数 ≥ チーム数」の場合に 1.6 まで到達します
- キーボード不足時は 1.5 で停止（UI上にメッセージ表示）
